### PR TITLE
Add more act options to extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,13 +314,25 @@
       },
       {
         "category": "GitHub Local Actions",
+        "command": "githubLocalActions.addOption",
+        "title": "Add Option",
+        "icon": "$(add)"
+      },
+      {
+        "category": "GitHub Local Actions",
+        "command": "githubLocalActions.editOption",
+        "title": "Edit",
+        "icon": "$(edit)"
+      },
+      {
+        "category": "GitHub Local Actions",
         "command": "githubLocalActions.openSettingFile",
         "title": "Open",
         "icon": "$(go-to-file)"
       },
       {
         "category": "GitHub Local Actions",
-        "command": "githubLocalActions.removeSettingFile",
+        "command": "githubLocalActions.removeCustomSetting",
         "title": "Remove",
         "icon": "$(close)"
       },
@@ -473,11 +485,19 @@
           "when": "never"
         },
         {
+          "command": "githubLocalActions.addOption",
+          "when": "never"
+        },
+        {
+          "command": "githubLocalActions.editOption",
+          "when": "never"
+        },
+        {
           "command": "githubLocalActions.openSettingFile",
           "when": "never"
         },
         {
-          "command": "githubLocalActions.removeSettingFile",
+          "command": "githubLocalActions.removeCustomSetting",
           "when": "never"
         },
         {
@@ -676,13 +696,23 @@
           "group": "inline@1"
         },
         {
+          "command": "githubLocalActions.addOption",
+          "when": "view == settings && viewItem =~ /^githubLocalActions.options.*/",
+          "group": "inline@0"
+        },
+        {
+          "command": "githubLocalActions.editOption",
+          "when": "view == settings && viewItem =~ /^githubLocalActions.option(?!s)_editable.*/",
+          "group": "inline@0"
+        },
+        {
           "command": "githubLocalActions.openSettingFile",
           "when": "view == settings && viewItem =~ /^githubLocalActions.(secret|variable|input|payload)File.*/",
           "group": "inline@0"
         },
         {
-          "command": "githubLocalActions.removeSettingFile",
-          "when": "view == settings && viewItem =~ /^githubLocalActions.(secret|variable|input|payload)File.*/",
+          "command": "githubLocalActions.removeCustomSetting",
+          "when": "view == settings && viewItem =~ /^githubLocalActions.((secret|variable|input|payload|)File|option(?!s)).*/",
           "group": "inline@1"
         },
         {
@@ -709,155 +739,6 @@
           "markdownDescription": "The path to your Docker Desktop executable (used for Windows and MacOS). To start Docker Engine from the `Components` view, this application will be launched. Refer to the default path based on OS:\n\n* **Windows**: `C:/Program Files/Docker/Docker/Docker Desktop.exe`\n\n* **MacOS**: `/Applications/Docker.app`",
           "type": "string",
           "default": ""
-        },
-        "githubLocalActions.act.actionCachePath": {
-          "description": "Defines the path where the actions get cached and host workspaces are created.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.actionOfflineMode": {
-          "description": "If action contents exists, it will not be fetch and pull again. If turn on this, will turn off force pull.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.actor": {
-          "description": "User that triggered the event.",
-          "type": "string",
-          "default": "nektos/act"
-        },
-        "githubLocalActions.act.artifactServerAddr": {
-          "markdownDescription": "Defines the address to which the artifact server binds. If not set, `nektos/act` will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.artifactServerPath": {
-          "description": "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified, the artifact server will not start.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.artifactServerPort": {
-          "description": "Defines the port where the artifact server listens.",
-          "type": "number",
-          "default": 34567
-        },
-        "githubLocalActions.act.bind": {
-          "description": "Bind working directory to container, rather than copy.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.cacheServerAddr": {
-          "markdownDescription": "Defines the address to which the cache server binds. If not set, `nektos/act` will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.cacheServerPath": {
-          "description": "Defines the path where the cache server stores caches.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.cacheServerPort": {
-          "markdownDescription": "Defines the port where the artifact server listens. `0` means a randomly available port.",
-          "type": "number",
-          "default": 0
-        },
-        "githubLocalActions.act.containerArchitecture": {
-          "markdownDescription": "The architecture which should be used to run containers (e.g.: `linux/amd64`). If not specified, the host default architecture will be used. This requires Docker server API Version 1.41+ (ignored on earlier Docker server platforms).",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.containerCapAdd": {
-          "markdownDescription": "Kernel capabilities to add to the workflow containers (e.g. `SYS_PTRACE`).",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "githubLocalActions.act.containerCapDrop": {
-          "markdownDescription": "Kernel capabilities to remove from the workflow containers (e.g. `SYS_PTRACE`).",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "githubLocalActions.act.containerDaemonSocket": {
-          "markdownDescription": "URI to Docker Engine socket (e.g.: `unix://~/.docker/run/docker.sock` or `-` to disable bind mounting the socket).",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.containerOptions": {
-          "description": "Custom docker container options for the job container without an options property in the job definition.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.defaultBranch": {
-          "description": "The name of the main branch.",
-          "type": "string",
-          "default": ""
-        },
-        "githubLocalActions.act.detectEvent": {
-          "description": "Use first event type from workflow as event that triggered the workflow.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.directory": {
-          "markdownDescription": "The working directory used when running a `nektos/act` command.",
-          "type": "string",
-          "default": "."
-        },
-        "githubLocalActions.act.githubInstance": {
-          "description": "The GitHub instance to use. Only use this when using GitHub Enterprise Server.",
-          "type": "string",
-          "default": "github.com"
-        },
-        "githubLocalActions.act.insecureSecrets": {
-          "markdownDescription": "Show secrets while printing logs (**NOT RECOMMENDED!**).",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.json": {
-          "description": "Output logs in json format.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.localRepository": {
-          "markdownDescription": "Replaces the specified repository and ref with a local folder (e.g. `https://github.com/test/test@v0=/home/act/test` or `test/test@v0=/home/act/test`, the latter matches any hosts or protocols).",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
-        },
-        "githubLocalActions.act.logPrefixJobId": {
-          "description": "Output the job id within non-json logs instead of the entire name.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.network": {
-          "description": "Sets a docker network name.",
-          "type": "string",
-          "default": "host"
-        },
-        "githubLocalActions.act.noCacheServer": {
-          "description": "Disable cache server.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.noRecurse": {
-          "markdownDescription": "Flag to disable running workflows from subdirectories of specified path in `--workflows`/`-W` flag.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.noSkipCheckout": {
-          "description": "Do not skip actions/checkout.",
-          "type": "boolean",
-          "default": false
-        },
-        "githubLocalActions.act.privileged": {
-          "description": "Use privileged mode.",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -685,12 +685,159 @@
     "configuration": {
       "title": "GitHub Local Actions",
       "properties": {
-        "githubLocalActions.dockerDesktopPath": {
-          "type": "string",
+        "githubLocalActions.dockerEngine.dockerDesktopPath": {
           "markdownDescription": "The path to your Docker Desktop executable (used for Windows and MacOS). To start Docker Engine from the `Components` view, this application will be launched. Refer to the default path based on OS:\n\n* **Windows**: `C:/Program Files/Docker/Docker/Docker Desktop.exe`\n\n* **MacOS**: `/Applications/Docker.app`",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.actionCachePath": {
+          "description": "Defines the path where the actions get cached and host workspaces are created.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.actionOfflineMode": {
+          "description": "If action contents exists, it will not be fetch and pull again. If turn on this, will turn off force pull.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.actor": {
+          "description": "User that triggered the event.",
+          "type": "string",
+          "default": "nektos/act"
+        },
+        "githubLocalActions.act.artifactServerAddr": {
+          "markdownDescription": "Defines the address to which the artifact server binds. If not set, `nektos/act` will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.artifactServerPath": {
+          "description": "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified, the artifact server will not start.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.artifactServerPort": {
+          "description": "Defines the port where the artifact server listens.",
+          "type": "number",
+          "default": 34567
+        },
+        "githubLocalActions.act.bind": {
+          "description": "Bind working directory to container, rather than copy.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.cacheServerAddr": {
+          "markdownDescription": "Defines the address to which the cache server binds. If not set, `nektos/act` will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.cacheServerPath": {
+          "description": "Defines the path where the cache server stores caches.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.cacheServerPort": {
+          "markdownDescription": "Defines the port where the artifact server listens. `0` means a randomly available port.",
+          "type": "number",
+          "default": 0
+        },
+        "githubLocalActions.act.containerArchitecture": {
+          "markdownDescription": "The architecture which should be used to run containers (e.g.: `linux/amd64`). If not specified, the host default architecture will be used. This requires Docker server API Version 1.41+ (ignored on earlier Docker server platforms).",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.containerCapAdd": {
+          "markdownDescription": "Kernel capabilities to add to the workflow containers (e.g. `SYS_PTRACE`).",
+          "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
+        },
+        "githubLocalActions.act.containerCapDrop": {
+          "markdownDescription": "Kernel capabilities to remove from the workflow containers (e.g. `SYS_PTRACE`).",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "githubLocalActions.act.containerDaemonSocket": {
+          "markdownDescription": "URI to Docker Engine socket (e.g.: `unix://~/.docker/run/docker.sock` or `-` to disable bind mounting the socket).",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.containerOptions": {
+          "description": "Custom docker container options for the job container without an options property in the job definition.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.defaultBranch": {
+          "description": "The name of the main branch.",
+          "type": "string",
+          "default": ""
+        },
+        "githubLocalActions.act.detectEvent": {
+          "description": "Use first event type from workflow as event that triggered the workflow.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.directory": {
+          "markdownDescription": "The working directory used when running a `nektos/act` command.",
+          "type": "string",
+          "default": "."
+        },
+        "githubLocalActions.act.githubInstance": {
+          "description": "The GitHub instance to use. Only use this when using GitHub Enterprise Server.",
+          "type": "string",
+          "default": "github.com"
+        },
+        "githubLocalActions.act.insecureSecrets": {
+          "markdownDescription": "Show secrets while printing logs (**NOT RECOMMENDED!**).",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.json": {
+          "description": "Output logs in json format.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.localRepository": {
+          "markdownDescription": "Replaces the specified repository and ref with a local folder (e.g. `https://github.com/test/test@v0=/home/act/test` or `test/test@v0=/home/act/test`, the latter matches any hosts or protocols).",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "githubLocalActions.act.logPrefixJobId": {
+          "description": "Output the job id within non-json logs instead of the entire name.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.network": {
+          "description": "Sets a docker network name.",
+          "type": "string",
+          "default": "host"
+        },
+        "githubLocalActions.act.noCacheServer": {
+          "description": "Disable cache server.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.noRecurse": {
+          "markdownDescription": "Flag to disable running workflows from subdirectories of specified path in `--workflows`/`-W` flag.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.noSkipCheckout": {
+          "description": "Do not skip actions/checkout.",
+          "type": "boolean",
+          "default": false
+        },
+        "githubLocalActions.act.privileged": {
+          "description": "Use privileged mode.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/act.ts
+++ b/src/act.ts
@@ -49,20 +49,67 @@ export enum Event {
 }
 
 export enum Option {
-    Workflows = '--workflows',
-    Job = '--job',
-    Platform = '--platform',
-    Secret = '--secret',
-    SecretFile = '--secret-file',
-    Variable = '--var',
-    VariableFile = '--var-file',
-    Input = '--input',
-    InputFile = '--input-file',
-    PayloadFile = '--eventpath',
-
-
-    ActionCachePath = '--action-cache-path',
-    ActionOfflineMode = '--action-offline-mode'
+    ActionCachePath = "--action-cache-path",
+    ActionOfflineMode = "--action-offline-mode",
+    Actor = "--actor",
+    ArtifactServerAddr = "--artifact-server-addr",
+    ArtifactServerPath = "--artifact-server-path",
+    ArtifactServerPort = "--artifact-server-port",
+    Bind = "--bind",
+    BugReport = "--bug-report",
+    CacheServerAddr = "--cache-server-addr",
+    CacheServerPath = "--cache-server-path",
+    CacheServerPort = "--cache-server-port",
+    ContainerArchitecture = "--container-architecture",
+    ContainerCapAdd = "--container-cap-add",
+    ContainerCapDrop = "--container-cap-drop",
+    ContainerDaemonSocket = "--container-daemon-socket",
+    ContainerOptions = "--container-options",
+    DefaultBranch = "--defaultbranch",
+    DetectEvent = "--detect-event",
+    Directory = "--directory",
+    DryRun = "--dryrun",
+    Env = "--env",
+    EnvFile = "--env-file",
+    EventPath = "--eventpath",
+    GithubInstance = "--github-instance",
+    Graph = "--graph",
+    Help = "--help",
+    Input = "--input",
+    InputFile = "--input-file",
+    InsecureSecrets = "--insecure-secrets",
+    Job = "--job",
+    Json = "--json",
+    List = "--list",
+    LocalRepository = "--local-repository",
+    LogPrefixJobId = "--log-prefix-job-id",
+    ManPage = "--man-page",
+    Matrix = "--matrix",
+    Network = "--network",
+    NoCacheServer = "--no-cache-server",
+    NoRecurse = "--no-recurse",
+    NoSkipCheckout = "--no-skip-checkout",
+    Platform = "--platform",
+    Privileged = "--privileged",
+    Pull = "--pull",
+    Quiet = "--quiet",
+    Rebuild = "--rebuild",
+    RemoteName = "--remote-name",
+    ReplaceGheActionTokenWithGithubCom = "--replace-ghe-action-token-with-github-com",
+    ReplaceGheActionWithGithubCom = "--replace-ghe-action-with-github-com",
+    Reuse = "--reuse",
+    Rm = "--rm",
+    Secret = "--secret",
+    SecretFile = "--secret-file",
+    UseGitignore = "--use-gitignore",
+    UseNewActionCache = "--use-new-action-cache",
+    Userns = "--userns",
+    Var = "--var",
+    VarFile = "--var-file",
+    Verbose = "--verbose",
+    Version = "--version",
+    Watch = "--watch",
+    Workflows = "--workflows",
 }
 
 export interface CommandArgs {
@@ -300,12 +347,13 @@ export class Act {
             `${actCommand} ${commandArgs.options}` +
             (settings.secrets.length > 0 ? ` ${Option.Secret} ${settings.secrets.map(secret => secret.key).join(` ${Option.Secret} `)}` : ``) +
             (settings.secretFiles.length > 0 ? ` ${Option.SecretFile} "${settings.secretFiles[0].path}"` : ` ${Option.SecretFile} ""`) +
-            (settings.variables.length > 0 ? ` ${Option.Variable} ${settings.variables.map(variable => `${variable.key}=${variable.value}`).join(` ${Option.Variable} `)}` : ``) +
-            (settings.variableFiles.length > 0 ? ` ${Option.VariableFile} "${settings.variableFiles[0].path}"` : ` ${Option.VariableFile} ""`) +
+            (settings.variables.length > 0 ? ` ${Option.Var} ${settings.variables.map(variable => `${variable.key}=${variable.value}`).join(` ${Option.Var} `)}` : ``) +
+            (settings.variableFiles.length > 0 ? ` ${Option.VarFile} "${settings.variableFiles[0].path}"` : ` ${Option.VarFile} ""`) +
             (settings.inputs.length > 0 ? ` ${Option.Input} ${settings.inputs.map(input => `${input.key}=${input.value}`).join(` ${Option.Input} `)}` : ``) +
             (settings.inputFiles.length > 0 ? ` ${Option.InputFile} "${settings.inputFiles[0].path}"` : ` ${Option.InputFile} ""`) +
             (settings.runners.length > 0 ? ` ${Option.Platform} ${settings.runners.map(runner => `${runner.key}=${runner.value}`).join(` ${Option.Platform} `)}` : ``) +
-            (settings.payloadFiles.length > 0 ? ` ${Option.PayloadFile} "${settings.payloadFiles[0].path}"` : ` ${Option.PayloadFile} ""`);
+            (settings.payloadFiles.length > 0 ? ` ${Option.EventPath} "${settings.payloadFiles[0].path}"` : ` ${Option.EventPath} ""`) +
+            (settings.options.map(option => option.path ? ` --${option.name} ${option.path}` : ` --${option.name}`).join(''));
 
         // Execute task
         const taskExecution = await tasks.executeTask({

--- a/src/act.ts
+++ b/src/act.ts
@@ -55,7 +55,11 @@ export enum Option {
     VariableFile = '--var-file',
     Input = '--input',
     InputFile = '--input-file',
-    PayloadFile = '--eventpath'
+    PayloadFile = '--eventpath',
+
+
+    ActionCachePath = '--action-cache-path',
+    ActionOfflineMode = '--action-offline-mode'
 }
 
 export interface CommandArgs {

--- a/src/configurationManager.ts
+++ b/src/configurationManager.ts
@@ -1,3 +1,5 @@
+import * as os from "os";
+import * as path from "path";
 import { ConfigurationTarget, workspace } from 'vscode';
 
 export enum Platform {
@@ -7,7 +9,8 @@ export enum Platform {
 }
 
 export enum Section {
-    dockerDesktopPath = 'dockerDesktopPath'
+    dockerDesktopPath = 'dockerDesktopPath',
+    actionCachePath = 'actionCachePath'
 }
 
 export namespace ConfigurationManager {
@@ -30,6 +33,13 @@ export namespace ConfigurationManager {
 
             ConfigurationManager.set(Section.dockerDesktopPath, dockerDesktopPath);
         }
+
+        let actionCachePath = ConfigurationManager.get<string>(Section.actionCachePath);
+        if (!actionCachePath) {
+            actionCachePath = getCacheDirectory(['act']);
+
+            ConfigurationManager.set(Section.actionCachePath, actionCachePath);
+        }
     }
 
     export function getSearchTerm(section: Section): string {
@@ -42,5 +52,11 @@ export namespace ConfigurationManager {
 
     export async function set(section: Section, value: any): Promise<void> {
         return await workspace.getConfiguration(ConfigurationManager.group).update(section, value, ConfigurationTarget.Global);
+    }
+
+    function getCacheDirectory(paths: string[]) {
+        const userHomeDir = os.homedir();
+        const cacheHomeDir = process.env.XDG_CACHE_HOME || path.join(userHomeDir, '.cache');
+        return path.join(cacheHomeDir, ...paths);
     }
 }

--- a/src/configurationManager.ts
+++ b/src/configurationManager.ts
@@ -1,5 +1,3 @@
-import * as os from "os";
-import * as path from "path";
 import { ConfigurationTarget, workspace } from 'vscode';
 import { Act } from './act';
 
@@ -11,8 +9,7 @@ export enum Platform {
 
 export enum Section {
     actCommand = 'actCommand',
-    dockerDesktopPath = 'dockerDesktopPath',
-    actionCachePath = 'actionCachePath'
+    dockerDesktopPath = 'dockerDesktopPath'
 }
 
 export namespace ConfigurationManager {
@@ -40,13 +37,6 @@ export namespace ConfigurationManager {
         if (!actCommand) {
             await ConfigurationManager.set(Section.actCommand, Act.defaultActCommand);
         }
-
-        let actionCachePath = ConfigurationManager.get<string>(Section.actionCachePath);
-        if (!actionCachePath) {
-            actionCachePath = getCacheDirectory(['act']);
-
-            ConfigurationManager.set(Section.actionCachePath, actionCachePath);
-        }
     }
 
     export function getSearchTerm(section: Section): string {
@@ -59,11 +49,5 @@ export namespace ConfigurationManager {
 
     export async function set(section: Section, value: any): Promise<void> {
         return await workspace.getConfiguration(ConfigurationManager.group).update(section, value, ConfigurationTarget.Global);
-    }
-
-    function getCacheDirectory(paths: string[]) {
-        const userHomeDir = os.homedir();
-        const cacheHomeDir = process.env.XDG_CACHE_HOME || path.join(userHomeDir, '.cache');
-        return path.join(cacheHomeDir, ...paths);
     }
 }

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -8,8 +8,9 @@ export enum StorageKey {
     VariableFiles = 'variableFiles',
     Inputs = 'inputs',
     InputFiles = 'inputFiles',
+    Runners = 'runners',
     PayloadFiles = 'PayloadFiles',
-    Runners = 'runners'
+    Options = 'options'
 }
 
 export class StorageManager {

--- a/src/views/decorationProvider.ts
+++ b/src/views/decorationProvider.ts
@@ -2,6 +2,8 @@ import { CancellationToken, Event, FileDecoration, FileDecorationProvider, Provi
 import { CliStatus, ExtensionStatus } from "../componentsManager";
 import ComponentTreeItem from "./components/component";
 import InputsTreeItem from "./settings/inputs";
+import OptionTreeItem from "./settings/option";
+import OptionsTreeItem from "./settings/options";
 import RunnersTreeItem from "./settings/runners";
 import SecretsTreeItem from "./settings/secrets";
 import { SettingContextValue } from "./settings/setting";
@@ -42,7 +44,7 @@ export class DecorationProvider implements FileDecorationProvider {
                     color: new ThemeColor('GitHubLocalActions.red')
                 };
             }
-        } else if ([SecretsTreeItem.contextValue, VariablesTreeItem.contextValue, InputsTreeItem.contextValue, RunnersTreeItem.contextValue].includes(uri.scheme)) {
+        } else if ([SecretsTreeItem.contextValue, VariablesTreeItem.contextValue, InputsTreeItem.contextValue, RunnersTreeItem.contextValue, OptionsTreeItem.contextValue].includes(uri.scheme)) {
             const hasAllValues = params.get('hasAllValues') === 'true';
 
             if (!hasAllValues) {
@@ -50,11 +52,12 @@ export class DecorationProvider implements FileDecorationProvider {
                     color: new ThemeColor('GitHubLocalActions.red')
                 };
             }
-        } else if (Object.values(SettingContextValue).includes(uri.scheme as any)) {
+        } else if ([...Object.values(SettingContextValue), OptionTreeItem].includes(uri.scheme as any)) {
             const isSelected = params.get('isSelected') === 'true';
             const hasValue = params.get('hasValue') === 'true';
+            const editable = params.get('editable') === 'true';
 
-            if (isSelected && !hasValue) {
+            if (isSelected && !hasValue && editable) {
                 return {
                     badge: '?',
                     color: new ThemeColor('GitHubLocalActions.red')

--- a/src/views/settings/inputs.ts
+++ b/src/views/settings/inputs.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, WorkspaceFolder } from "vscode";
 import { act } from "../../extension";
-import { Setting, SettingFile } from "../../settingsManager";
+import { CustomSetting, Setting } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import SettingTreeItem from "./setting";
@@ -10,7 +10,7 @@ export default class InputsTreeItem extends TreeItem implements GithubLocalActio
     static contextValue = 'githubLocalActions.inputs';
     storageKey = StorageKey.InputFiles;
 
-    constructor(public workspaceFolder: WorkspaceFolder, inputs: Setting[], inputFiles: SettingFile[]) {
+    constructor(public workspaceFolder: WorkspaceFolder, inputs: Setting[], inputFiles: CustomSetting[]) {
         super('Inputs', TreeItemCollapsibleState.Collapsed);
         const selectedInputFiles = inputFiles.filter(inputFile => inputFile.selected);
         this.description = `${inputs.filter(input => input.selected).length}/${inputs.length}` +

--- a/src/views/settings/option.ts
+++ b/src/views/settings/option.ts
@@ -1,0 +1,29 @@
+import { ThemeIcon, TreeItem, TreeItemCheckboxState, TreeItemCollapsibleState, Uri, WorkspaceFolder } from "vscode";
+import { CustomSetting } from "../../settingsManager";
+import { StorageKey } from "../../storageManager";
+import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
+
+export default class OptionTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
+    static contextValue = 'githubLocalActions.option';
+    option: CustomSetting;
+    storageKey: StorageKey;
+
+    constructor(public workspaceFolder: WorkspaceFolder, option: CustomSetting) {
+        super(option.name, TreeItemCollapsibleState.None);
+        this.option = option;
+        this.storageKey = StorageKey.Options;
+        this.description = option.path;
+        this.contextValue = `${OptionTreeItem.contextValue}_${option.notEditable ? `` : `editable`}`;
+        this.iconPath = new ThemeIcon('symbol-property');
+        this.checkboxState = option.selected ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
+        this.tooltip = `Option: ${option.name}\n` +
+            (option.path ? `Value: ${option.path}\n` : ``) +
+            (option.default ? `Default: ${option.default}\n` : ``) +
+            `Description: ${option.description}`;
+        this.resourceUri = Uri.parse(`${OptionTreeItem.contextValue}:${option.name}?isSelected=${option.selected}&hasValue=${option.path !== ''}&editable=${!option.notEditable}`, true);
+    }
+
+    async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
+        return [];
+    }
+}

--- a/src/views/settings/options.ts
+++ b/src/views/settings/options.ts
@@ -1,0 +1,32 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, WorkspaceFolder } from "vscode";
+import { act } from "../../extension";
+import { CustomSetting } from "../../settingsManager";
+import { StorageKey } from "../../storageManager";
+import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
+import OptionTreeItem from "./option";
+
+export default class OptionsTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
+    static contextValue = 'githubLocalActions.options';
+    storageKey: StorageKey;
+
+    constructor(public workspaceFolder: WorkspaceFolder, options: CustomSetting[]) {
+        super('Options', TreeItemCollapsibleState.Collapsed);
+        this.storageKey = StorageKey.Options;
+        this.description = `${options.filter(option => option.selected).length}/${options.length}`;
+        this.contextValue = OptionsTreeItem.contextValue;
+        this.iconPath = new ThemeIcon('gear');
+        const hasAllValues = options.filter(option => option.selected && option.path === '' && !option.notEditable).length === 0;
+        this.resourceUri = Uri.parse(`${OptionsTreeItem.contextValue}:Options?hasAllValues=${hasAllValues}`, true);
+    }
+
+    async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
+        const items: GithubLocalActionsTreeItem[] = [];
+
+        const settings = await act.settingsManager.getSettings(this.workspaceFolder, false);
+        for (const option of settings.options) {
+            items.push(new OptionTreeItem(this.workspaceFolder, option));
+        }
+
+        return items.sort((a, b) => a.label!.toString().localeCompare(b.label!.toString()));
+    }
+}

--- a/src/views/settings/payloads.ts
+++ b/src/views/settings/payloads.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
 import { act } from "../../extension";
-import { SettingFile } from "../../settingsManager";
+import { CustomSetting } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import SettingFileTreeItem from "./settingFile";
@@ -9,7 +9,7 @@ export default class PayloadsTreeItem extends TreeItem implements GithubLocalAct
     static contextValue = 'githubLocalActions.payloads';
     storageKey = StorageKey.PayloadFiles;
 
-    constructor(public workspaceFolder: WorkspaceFolder, payloadFiles: SettingFile[]) {
+    constructor(public workspaceFolder: WorkspaceFolder, payloadFiles: CustomSetting[]) {
         super('Payloads', TreeItemCollapsibleState.Collapsed);
         const selectedPayloadFiles = payloadFiles.filter(payloadFile => payloadFile.selected);
         this.description = selectedPayloadFiles.length > 0 ? `${selectedPayloadFiles[0].name}` : ``;

--- a/src/views/settings/secrets.ts
+++ b/src/views/settings/secrets.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, WorkspaceFolder } from "vscode";
 import { act } from "../../extension";
-import { Setting, SettingFile } from "../../settingsManager";
+import { CustomSetting, Setting } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import SettingTreeItem from "./setting";
@@ -10,7 +10,7 @@ export default class SecretsTreeItem extends TreeItem implements GithubLocalActi
     static contextValue = 'githubLocalActions.secrets';
     storageKey = StorageKey.SecretFiles;
 
-    constructor(public workspaceFolder: WorkspaceFolder, secrets: Setting[], secretFiles: SettingFile[]) {
+    constructor(public workspaceFolder: WorkspaceFolder, secrets: Setting[], secretFiles: CustomSetting[]) {
         super('Secrets', TreeItemCollapsibleState.Collapsed);
         const selectedSecretFiles = secretFiles.filter(secretFile => secretFile.selected);
         this.description = `${secrets.filter(secret => secret.selected).length}/${secrets.length}` +

--- a/src/views/settings/settingFile.ts
+++ b/src/views/settings/settingFile.ts
@@ -1,13 +1,13 @@
 import { ThemeIcon, TreeItem, TreeItemCheckboxState, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
-import { SettingFile } from "../../settingsManager";
+import { CustomSetting } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 
 export default class SettingFileTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
-    settingFile: SettingFile;
+    settingFile: CustomSetting;
     storageKey: StorageKey;
 
-    constructor(public workspaceFolder: WorkspaceFolder, settingFile: SettingFile, storageKey: StorageKey, treeItem: { contextValue: string, iconPath: ThemeIcon }) {
+    constructor(public workspaceFolder: WorkspaceFolder, settingFile: CustomSetting, storageKey: StorageKey, treeItem: { contextValue: string, iconPath: ThemeIcon }) {
         super(settingFile.name, TreeItemCollapsibleState.None);
         this.settingFile = settingFile;
         this.storageKey = storageKey;
@@ -16,10 +16,10 @@ export default class SettingFileTreeItem extends TreeItem implements GithubLocal
         this.iconPath = treeItem.iconPath;
         this.checkboxState = settingFile.selected ? TreeItemCheckboxState.Checked : TreeItemCheckboxState.Unchecked;
         this.tooltip = `Name: ${settingFile.name}\n` +
-            `Path: ${settingFile.path}\n`;
+            `Path: ${settingFile.path}`;
     }
 
-    static getSecretTreeItem(workspaceFolder: WorkspaceFolder, secretFile: SettingFile): SettingFileTreeItem {
+    static getSecretTreeItem(workspaceFolder: WorkspaceFolder, secretFile: CustomSetting): SettingFileTreeItem {
         return new SettingFileTreeItem(
             workspaceFolder,
             secretFile,
@@ -31,7 +31,7 @@ export default class SettingFileTreeItem extends TreeItem implements GithubLocal
         );
     }
 
-    static getVariableTreeItem(workspaceFolder: WorkspaceFolder, variableFile: SettingFile): SettingFileTreeItem {
+    static getVariableTreeItem(workspaceFolder: WorkspaceFolder, variableFile: CustomSetting): SettingFileTreeItem {
         return new SettingFileTreeItem(
             workspaceFolder,
             variableFile,
@@ -43,7 +43,7 @@ export default class SettingFileTreeItem extends TreeItem implements GithubLocal
         );
     }
 
-    static getInputTreeItem(workspaceFolder: WorkspaceFolder, inputFile: SettingFile): SettingFileTreeItem {
+    static getInputTreeItem(workspaceFolder: WorkspaceFolder, inputFile: CustomSetting): SettingFileTreeItem {
         return new SettingFileTreeItem(
             workspaceFolder,
             inputFile,
@@ -55,7 +55,7 @@ export default class SettingFileTreeItem extends TreeItem implements GithubLocal
         );
     }
 
-    static getPayloadTreeItem(workspaceFolder: WorkspaceFolder, payloadFile: SettingFile): SettingFileTreeItem {
+    static getPayloadTreeItem(workspaceFolder: WorkspaceFolder, payloadFile: CustomSetting): SettingFileTreeItem {
         return new SettingFileTreeItem(
             workspaceFolder,
             payloadFile,

--- a/src/views/settings/settingsTreeDataProvider.ts
+++ b/src/views/settings/settingsTreeDataProvider.ts
@@ -1,9 +1,14 @@
+import * as os from "os";
+import * as path from "path";
 import { CancellationToken, commands, EventEmitter, ExtensionContext, QuickPickItem, QuickPickItemKind, ThemeIcon, TreeCheckboxChangeEvent, TreeDataProvider, TreeItem, TreeItemCheckboxState, Uri, window, workspace } from "vscode";
+import { Option } from "../../act";
 import { act } from "../../extension";
 import { SettingFileName, Visibility } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import InputsTreeItem from "./inputs";
+import OptionTreeItem from "./option";
+import OptionsTreeItem from "./options";
 import PayloadsTreeItem from "./payloads";
 import SecretsTreeItem from "./secrets";
 import SettingTreeItem from "./setting";
@@ -111,6 +116,242 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
                     this.refresh();
                 }
             }),
+            commands.registerCommand('githubLocalActions.addOption', async (optionsTreeItem: OptionsTreeItem) => {
+                let options: any[] = [
+                    {
+                        label: Option.ActionCachePath,
+                        description: this.getCacheDirectory(['act']),
+                        detail: 'Defines the path where the actions get cached and host workspaces are created.'
+                    },
+                    {
+                        label: Option.ActionOfflineMode,
+                        detail: 'If action contents exists, it will not be fetched and pulled again. If this is turned on, it will turn off force pull.'
+                    },
+                    {
+                        label: Option.Actor,
+                        description: 'nektos/act',
+                        detail: 'User that triggered the event.'
+                    },
+                    {
+                        label: Option.ArtifactServerAddr,
+                        description: '',
+                        detail: 'Defines the address to which the artifact server binds. If not set, nektos/act will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.'
+                    },
+                    {
+                        label: Option.ArtifactServerPath,
+                        description: '',
+                        detail: 'Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified, the artifact server will not start.'
+                    },
+                    {
+                        label: Option.ArtifactServerPort,
+                        description: '34567',
+                        detail: 'Defines the port where the artifact server listens.'
+                    },
+                    {
+                        label: Option.Bind,
+                        detail: 'Bind working directory to container, rather than copy.'
+                    },
+                    {
+                        label: Option.CacheServerAddr,
+                        description: '',
+                        detail: 'Defines the address to which the cache server binds. If not set, nektos/act will use the outbound IP address of this machine. This means that it will try to access the internet and return the local IP address of the connection. If the machine cannot access the internet, it returns a preferred IP address from network interfaces. If no IP address is found, this will not be set.'
+                    },
+                    {
+                        label: Option.CacheServerPath,
+                        description: this.getCacheDirectory(['actcache']),
+                        detail: 'Defines the path where the cache server stores caches.'
+                    },
+                    {
+                        label: Option.CacheServerPort,
+                        description: '0',
+                        detail: 'Defines the port where the artifact server listens. 0 means a randomly available port.'
+                    },
+                    {
+                        label: Option.ContainerArchitecture,
+                        description: '',
+                        detail: 'The architecture which should be used to run containers (e.g.: linux/amd64). If not specified, the host default architecture will be used. This requires Docker server API Version 1.41+ (ignored on earlier Docker server platforms).'
+                    },
+                    {
+                        label: Option.ContainerCapAdd,
+                        description: '',
+                        detail: 'Kernel capabilities to add to the workflow containers (e.g. SYS_PTRACE).'
+                    },
+                    {
+                        label: Option.ContainerCapDrop,
+                        description: '',
+                        detail: 'Kernel capabilities to remove from the workflow containers (e.g. SYS_PTRACE).'
+                    },
+                    {
+                        label: Option.ContainerDaemonSocket,
+                        description: '',
+                        detail: 'URI to Docker Engine socket (e.g.: unix://~/.docker/run/docker.sock or - to disable bind mounting the socket).'
+                    },
+                    {
+                        label: Option.ContainerOptions,
+                        description: '',
+                        detail: 'Custom docker container options for the job container without an options property in the job definition.'
+                    },
+                    {
+                        label: Option.DefaultBranch,
+                        description: '',
+                        detail: 'The name of the main branch.'
+                    },
+                    {
+                        label: Option.DetectEvent,
+                        detail: 'Use first event type from workflow as event that triggered the workflow.'
+                    },
+                    {
+                        label: Option.Directory,
+                        description: '.',
+                        detail: 'The working directory used when running a nektos/act command.'
+                    },
+                    {
+                        label: Option.DryRun,
+                        detail: 'Disable container creation and validate only workflow correctness.'
+                    },
+                    {
+                        label: Option.GithubInstance,
+                        description: 'github.com',
+                        detail: 'The GitHub instance to use. Only use this when using GitHub Enterprise Server.'
+                    },
+                    {
+                        label: Option.InsecureSecrets,
+                        detail: 'Show secrets while printing logs (NOT RECOMMENDED!).'
+                    },
+                    {
+                        label: Option.Json,
+                        detail: 'Output logs in json format.'
+                    },
+                    {
+                        label: Option.LocalRepository,
+                        description: '',
+                        detail: 'Replaces the specified repository and ref with a local folder (e.g. https://github.com/test/test@v0=/home/act/test or test/test@v0=/home/act/test, the latter matches any hosts or protocols).'
+                    },
+                    {
+                        label: Option.LogPrefixJobId,
+                        detail: 'Output the job id within non-json logs instead of the entire name.'
+                    },
+                    {
+                        label: Option.Network,
+                        description: 'host',
+                        detail: 'Sets a docker network name.'
+                    },
+                    {
+                        label: Option.NoCacheServer,
+                        detail: 'Disable cache server.'
+                    },
+                    {
+                        label: Option.NoRecurse,
+                        detail: 'Flag to disable running workflows from subdirectories of specified path in --workflows/-W flag.'
+                    },
+                    {
+                        label: Option.NoSkipCheckout,
+                        detail: 'Do not skip actions/checkout.'
+                    },
+                    {
+                        label: Option.Privileged,
+                        detail: 'Use privileged mode.'
+                    },
+                    {
+                        label: Option.Pull,
+                        detail: 'Pull docker image(s) even if already present.'
+                    },
+                    {
+                        label: Option.Quiet,
+                        detail: 'Disable logging of output from steps.'
+                    },
+                    {
+                        label: Option.Rebuild,
+                        detail: 'Rebuild local action docker image(s) even if already present.'
+                    },
+                    {
+                        label: Option.RemoteName,
+                        description: 'origin',
+                        detail: 'Git remote name that will be used to retrieve the URL of Git repo.'
+                    },
+                    {
+                        label: Option.ReplaceGheActionTokenWithGithubCom,
+                        description: '',
+                        detail: 'If you are using replace-ghe-action-with-github-com and you want to use private actions on GitHub, you have to set a personal access token.'
+                    },
+                    {
+                        label: Option.ReplaceGheActionWithGithubCom,
+                        description: '',
+                        detail: 'If you are using GitHub Enterprise Server and allow specified actions from GitHub (github.com), you can set actions on this.'
+                    },
+                    {
+                        label: Option.Reuse,
+                        detail: 'Don\'t remove container(s) on successfully completed workflow(s) to maintain state between runs.'
+                    },
+                    {
+                        label: Option.Rm,
+                        detail: 'Automatically remove container(s)/volume(s) after a workflow(s) failure.'
+                    },
+                    {
+                        label: Option.UseGitignore,
+                        detail: 'Controls whether paths specified in a .gitignore file should be copied into the container.'
+                    },
+                    {
+                        label: Option.UseNewActionCache,
+                        detail: 'Enable using the new Action Cache for storing Actions locally.'
+                    },
+                    {
+                        label: Option.Userns,
+                        description: '',
+                        detail: 'User namespace to use.'
+                    },
+                    {
+                        label: Option.Verbose,
+                        detail: 'Enable verbose output.'
+                    }
+                ];
+
+                options.forEach((option, index) => {
+                    options[index].label = options[index].label.slice(2)
+                    options[index].iconPath = new ThemeIcon('symbol-property');
+                })
+
+                const settings = await act.settingsManager.getSettings(optionsTreeItem.workspaceFolder, false);
+                const optionNames = settings.options.map(option => option.name);
+                options = options.filter(option => !optionNames.includes(option.label));
+
+                const selectedOption = await window.showQuickPick(options, {
+                    title: 'Select the option to add',
+                    placeHolder: 'Option',
+                    matchOnDetail: true
+                });
+
+                if (selectedOption) {
+                    const requiresInputFromUser: boolean = selectedOption.description !== undefined;
+                    let value: string | undefined;
+
+                    if (requiresInputFromUser) {
+                        value = await window.showInputBox({
+                            prompt: `Enter a value for the option`,
+                            placeHolder: `Option value`,
+                            value: selectedOption.description
+                        });
+
+                        if (value === undefined) {
+                            return;
+                        }
+                    }
+
+                    await act.settingsManager.editCustomSetting(
+                        optionsTreeItem.workspaceFolder,
+                        {
+                            name: selectedOption.label,
+                            path: value || '',
+                            selected: false,
+                            notEditable: !requiresInputFromUser,
+                            default: selectedOption.description,
+                            description: selectedOption.detail
+                        },
+                        optionsTreeItem.storageKey
+                    );
+                    this.refresh();
+                }
+            }),
             commands.registerCommand('githubLocalActions.locatePayloadFiles', async (payloadsTreeItem: PayloadsTreeItem) => {
                 const payloadFilesUris = await window.showOpenDialog({
                     title: 'Locate Payload Files',
@@ -122,6 +363,20 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
 
                 if (payloadFilesUris) {
                     await act.settingsManager.locateSettingFile(payloadsTreeItem.workspaceFolder, payloadsTreeItem.storageKey, payloadFilesUris);
+                    this.refresh();
+                }
+            }),
+            commands.registerCommand('githubLocalActions.editOption', async (optionTreeItem: OptionTreeItem) => {
+                const value = await window.showInputBox({
+                    prompt: `Enter a value for the option (${optionTreeItem.option.name})`,
+                    placeHolder: `Option value`,
+                    value: optionTreeItem.option.path
+                });
+
+                if (value !== undefined) {
+                    const newOption = optionTreeItem.option;
+                    newOption.path = value;
+                    await act.settingsManager.editCustomSetting(optionTreeItem.workspaceFolder, newOption, optionTreeItem.storageKey);
                     this.refresh();
                 }
             }),
@@ -138,8 +393,11 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
                     }
                 }
             }),
-            commands.registerCommand('githubLocalActions.removeSettingFile', async (settingFileTreeItem: SettingFileTreeItem) => {
-                await act.settingsManager.removeSettingFile(settingFileTreeItem.workspaceFolder, settingFileTreeItem.settingFile, settingFileTreeItem.storageKey);
+            commands.registerCommand('githubLocalActions.removeCustomSetting', async (customTreeItem: SettingFileTreeItem | OptionTreeItem) => {
+                const existingCustomSetting = customTreeItem instanceof SettingFileTreeItem ?
+                    customTreeItem.settingFile :
+                    customTreeItem.option;
+                await act.settingsManager.removeCustomSetting(customTreeItem.workspaceFolder, existingCustomSetting, customTreeItem.storageKey);
                 this.refresh();
             }),
             commands.registerCommand('githubLocalActions.deleteSettingFile', async (settingFileTreeItem: SettingFileTreeItem) => {
@@ -297,28 +555,32 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
         return element;
     }
 
-    async onDidChangeCheckboxState(event: TreeCheckboxChangeEvent<SettingTreeItem | SettingFileTreeItem>) {
+    async onDidChangeCheckboxState(event: TreeCheckboxChangeEvent<SettingTreeItem | SettingFileTreeItem | OptionTreeItem>) {
         for await (const [treeItem, state] of event.items) {
             if (treeItem instanceof SettingTreeItem) {
                 const newSetting = treeItem.setting;
                 newSetting.selected = (state === TreeItemCheckboxState.Checked);
                 await act.settingsManager.editSetting(treeItem.workspaceFolder, newSetting, treeItem.storageKey);
+            } else if (treeItem instanceof OptionTreeItem) {
+                const newOption = treeItem.option;
+                newOption.selected = (state === TreeItemCheckboxState.Checked);
+                await act.settingsManager.editCustomSetting(treeItem.workspaceFolder, newOption, treeItem.storageKey);
             } else {
                 const isSelected = (state === TreeItemCheckboxState.Checked);
 
                 // Update check box state for current setting file tree item
                 const newSettingFile = treeItem.settingFile;
                 newSettingFile.selected = isSelected;
-                await act.settingsManager.editSettingFile(treeItem.workspaceFolder, newSettingFile, treeItem.storageKey);
+                await act.settingsManager.editCustomSetting(treeItem.workspaceFolder, newSettingFile, treeItem.storageKey);
 
                 // Update check box state for other setting file tree items
                 if (isSelected) {
-                    const settingFiles = await act.settingsManager.getSettingFiles(treeItem.workspaceFolder, treeItem.storageKey);
+                    const settingFiles = await act.settingsManager.getCustomSettings(treeItem.workspaceFolder, treeItem.storageKey);
                     for (const settingFile of settingFiles) {
                         if (settingFile.selected && settingFile.path !== treeItem.settingFile.path) {
                             const newSettingFile = settingFile;
                             newSettingFile.selected = false;
-                            await act.settingsManager.editSettingFile(treeItem.workspaceFolder, newSettingFile, treeItem.storageKey);
+                            await act.settingsManager.editCustomSetting(treeItem.workspaceFolder, newSettingFile, treeItem.storageKey);
                         }
                     }
                 }
@@ -358,5 +620,11 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
             await commands.executeCommand('setContext', 'githubLocalActions:noSettings', noSettings);
             return items;
         }
+    }
+
+    getCacheDirectory(paths: string[]) {
+        const userHomeDir = os.homedir();
+        const cacheHomeDir = process.env.XDG_CACHE_HOME || path.join(userHomeDir, '.cache');
+        return path.join(cacheHomeDir, ...paths);
     }
 }

--- a/src/views/settings/variables.ts
+++ b/src/views/settings/variables.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri, WorkspaceFolder } from "vscode";
 import { act } from "../../extension";
-import { Setting, SettingFile } from "../../settingsManager";
+import { CustomSetting, Setting } from "../../settingsManager";
 import { StorageKey } from "../../storageManager";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import SettingTreeItem from "./setting";
@@ -10,7 +10,7 @@ export default class VariablesTreeItem extends TreeItem implements GithubLocalAc
     static contextValue = 'githubLocalActions.variables';
     storageKey = StorageKey.VariableFiles;
 
-    constructor(public workspaceFolder: WorkspaceFolder, variables: Setting[], variableFiles: SettingFile[]) {
+    constructor(public workspaceFolder: WorkspaceFolder, variables: Setting[], variableFiles: CustomSetting[]) {
         super('Variables', TreeItemCollapsibleState.Collapsed);
         const selectedVariableFiles = variableFiles.filter(variableFile => variableFile.selected);
         this.description = `${variables.filter(variable => variable.selected).length}/${variables.length}` +

--- a/src/views/settings/workspaceFolderSettings.ts
+++ b/src/views/settings/workspaceFolderSettings.ts
@@ -2,6 +2,7 @@ import { ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "
 import { act } from "../../extension";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
 import InputsTreeItem from "./inputs";
+import OptionsTreeItem from "./options";
 import PayloadsTreeItem from "./payloads";
 import RunnersTreeItem from "./runners";
 import SecretsTreeItem from "./secrets";
@@ -25,7 +26,8 @@ export default class WorkspaceFolderSettingsTreeItem extends TreeItem implements
             new VariablesTreeItem(this.workspaceFolder, settings.variables, settings.variableFiles),
             new InputsTreeItem(this.workspaceFolder, settings.inputs, settings.inputFiles),
             new RunnersTreeItem(this.workspaceFolder, settings.runners),
-            new PayloadsTreeItem(this.workspaceFolder, settings.payloadFiles)
+            new PayloadsTreeItem(this.workspaceFolder, settings.payloadFiles),
+            new OptionsTreeItem(this.workspaceFolder, settings.options)
         ]);
 
         return items;


### PR DESCRIPTION
### Changes
- [x] Add new `Options` tree item heading to `Settings` view
- [x] `Add Option` command will support adding all the other act options
- [x] Add red tree item decorations when options that require a value are not set (also propagated to the `Options` heading)