### PR TITLE
Suggest .vars instead of .env for Action Variables

### DIFF
--- a/src/settingsManager.ts
+++ b/src/settingsManager.ts
@@ -38,7 +38,8 @@ export enum Visibility {
 
 export enum SettingFileName {
     secretFile = '.secrets',
-    variableFile = '.env',
+    envFile = '.env',
+    variableFile = '.vars',
     inputFile = '.input',
     payloadFile = 'payload.json'
 }


### PR DESCRIPTION
Those are not used for the same purpose.

--env-file is used for `${{env.NAME}}`
--var-file is used for `${{vars.NAME}}`

_envFile support is not implemented here_