### PR TITLE
Add support for job and step level execution status

### DIFF
--- a/package.json
+++ b/package.json
@@ -745,7 +745,7 @@
     "colors": [
       {
         "id": "GitHubLocalActions.green",
-        "description": "Color for green in GitHub Local Actions extension",
+        "description": "Color for green in the GitHub Local Actions extension",
         "defaults": {
           "dark": "#89d185",
           "light": "#89d185"
@@ -753,15 +753,23 @@
       },
       {
         "id": "GitHubLocalActions.yellow",
-        "description": "Color for yellow in GitHub Local Actions extension",
+        "description": "Color for yellow in the GitHub Local Actions extension",
         "defaults": {
           "dark": "#cca700",
           "light": "#cca700"
         }
       },
       {
+        "id": "GitHubLocalActions.purple",
+        "description": "Color for purple in the GitHub Local Actions extension",
+        "defaults": {
+          "dark": "#d6bcfa",
+          "light": "#d6bcfa"
+        }
+      },
+      {
         "id": "GitHubLocalActions.red",
-        "description": "Color for red in GitHub Local Actions extension",
+        "description": "Color for red in the GitHub Local Actions extension",
         "defaults": {
           "dark": "#f48771",
           "light": "#f48771"

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
       },
       {
         "category": "GitHub Local Actions",
+        "command": "githubLocalActions.focusTask",
+        "title": "Focus Task"
+      },
+      {
+        "category": "GitHub Local Actions",
         "command": "githubLocalActions.refreshSettings",
         "title": "Refresh",
         "icon": "$(refresh)"
@@ -434,6 +439,10 @@
         },
         {
           "command": "githubLocalActions.remove",
+          "when": "never"
+        },
+        {
+          "command": "githubLocalActions.focusTask",
           "when": "never"
         },
         {
@@ -639,6 +648,11 @@
           "command": "githubLocalActions.remove",
           "when": "view == history && viewItem =~ /^githubLocalActions.history.*/",
           "group": "inline@3"
+        },
+        {
+          "command": "githubLocalActions.focusTask",
+          "when": "view == history && viewItem =~ /^githubLocalActions.history.*/",
+          "group": "0_focus@0"
         },
         {
           "command": "githubLocalActions.createSecretFile",

--- a/src/act.ts
+++ b/src/act.ts
@@ -505,7 +505,7 @@ export class Act {
                                             const preStepName = `Pre ${parsedMessage.step}`;
                                             let preStepIndex = this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps!
                                                 .findIndex(step => step.id === stepId && step.name === preStepName);
-                                            if (this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![preStepIndex].status === HistoryStatus.Running) {
+                                            if (preStepIndex > -1 && this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![preStepIndex].status === HistoryStatus.Running) {
 
                                                 this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![preStepIndex].status = HistoryStatus.Success;
                                                 this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![preStepIndex].date.end = dateString;

--- a/src/act.ts
+++ b/src/act.ts
@@ -467,14 +467,15 @@ export class Act {
                                                 start: dateString
                                             },
                                             steps: [
-                                                {
-                                                    id: "--setup-job", // Special id for setup job
-                                                    name: 'Setup Job',
-                                                    status: HistoryStatus.Running,
-                                                    date: {
-                                                        start: dateString
-                                                    }
-                                                }
+                                                // TODO: Add setup job step. To be fixed with https://github.com/nektos/act/issues/2551
+                                                // {
+                                                //     id: "--setup-job", // Special id for setup job
+                                                //     name: 'Setup Job',
+                                                //     status: HistoryStatus.Running,
+                                                //     date: {
+                                                //         start: dateString
+                                                //     }
+                                                // }
                                             ]
                                         });
                                         jobIndex = this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs!.length - 1;
@@ -512,11 +513,12 @@ export class Act {
                                             }
                                         }
 
-                                        if (this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].status === HistoryStatus.Running) {
-                                            // TODO: This forcefully sets the setup job step to success. To be fixed with https://github.com/nektos/act/issues/2551
-                                            this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].status = HistoryStatus.Success;
-                                            this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].date.end = dateString;
-                                        }
+                                        // TODO: Add setup job status check. To be fixed with https://github.com/nektos/act/issues/2551
+                                        // if (this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].status === HistoryStatus.Running) {
+                                        //     // TODO: This forcefully sets the setup job step to success. To be fixed with https://github.com/nektos/act/issues/2551
+                                        //     this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].status = HistoryStatus.Success;
+                                        //     this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].date.end = dateString;
+                                        // }
 
                                         let stepIndex = this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps!
                                             .findIndex(step => step.id === stepId && step.name === stepName);

--- a/src/act.ts
+++ b/src/act.ts
@@ -528,8 +528,8 @@ export class Act {
 
                         writeEmitter.fire(`${message.trimEnd()}\r\n`);
                         historyTreeDataProvider.refresh();
-                        await this.storageManager.update(StorageKey.WorkspaceHistory, this.historyManager.workspaceHistory);
                     }
+                    await this.storageManager.update(StorageKey.WorkspaceHistory, this.historyManager.workspaceHistory);
                 };
 
                 let shell = env.shell;

--- a/src/historyManager.ts
+++ b/src/historyManager.ts
@@ -90,7 +90,7 @@ export class HistoryManager {
 
         this.workspaceHistory[workspaceFolder.uri.fsPath] = [];
         historyTreeDataProvider.refresh();
-        this.storageManager.update(StorageKey.WorkspaceHistory, this.workspaceHistory);
+        await this.storageManager.update(StorageKey.WorkspaceHistory, this.workspaceHistory);
     }
 
     async viewOutput(history: History) {
@@ -114,7 +114,7 @@ export class HistoryManager {
         const historyIndex = this.workspaceHistory[history.commandArgs.path].findIndex(workspaceHistory => workspaceHistory.index === history.index);
         if (historyIndex > -1) {
             this.workspaceHistory[history.commandArgs.path].splice(historyIndex, 1);
-            this.storageManager.update(StorageKey.WorkspaceHistory, this.workspaceHistory);
+            await this.storageManager.update(StorageKey.WorkspaceHistory, this.workspaceHistory);
 
             try {
                 await workspace.fs.delete(Uri.file(history.logPath));

--- a/src/settingsManager.ts
+++ b/src/settingsManager.ts
@@ -15,7 +15,7 @@ export interface Settings {
     runners: Setting[];
     payloadFiles: CustomSetting[];
     options: CustomSetting[];
-    environments: Setting[];
+    // environments: Setting[];
 }
 
 export interface Setting {
@@ -74,7 +74,7 @@ export class SettingsManager {
         const runners = (await this.getSetting(workspaceFolder, SettingsManager.runnersRegExp, StorageKey.Runners, false, Visibility.show)).filter(runner => !isUserSelected || (runner.selected && runner.value));
         const payloadFiles = (await this.getCustomSettings(workspaceFolder, StorageKey.PayloadFiles)).filter(payloadFile => !isUserSelected || payloadFile.selected);
         const options = (await this.getCustomSettings(workspaceFolder, StorageKey.Options)).filter(option => !isUserSelected || (option.selected && (option.path || option.notEditable)));
-        const environments = await this.getEnvironments(workspaceFolder);
+        // const environments = await this.getEnvironments(workspaceFolder);
 
         return {
             secrets: secrets,
@@ -86,7 +86,7 @@ export class SettingsManager {
             runners: runners,
             payloadFiles: payloadFiles,
             options: options,
-            environments: environments
+            // environments: environments
         };
     }
 
@@ -131,7 +131,7 @@ export class SettingsManager {
             }
         }
         existingSettings[workspaceFolder.uri.fsPath] = settings;
-        this.storageManager.update(storageKey, existingSettings);
+        await this.storageManager.update(storageKey, existingSettings);
 
         return settings;
     }

--- a/src/views/history/history.ts
+++ b/src/views/history/history.ts
@@ -34,11 +34,6 @@ export default class HistoryTreeItem extends TreeItem implements GithubLocalActi
             `Started: ${Utils.getDateString(history.date.start)}\n` +
             `Ended: ${endTime ? Utils.getDateString(endTime) : 'N/A'}\n` +
             `Total Duration: ${totalDuration ? totalDuration : 'N/A'}`;
-        // this.command = {
-        //     title: 'Focus Task',
-        //     command: 'githubLocalActions.focusTask',
-        //     arguments: [this]
-        // };
     }
 
     async getChildren(): Promise<GithubLocalActionsTreeItem[]> {

--- a/src/views/history/history.ts
+++ b/src/views/history/history.ts
@@ -1,15 +1,16 @@
 import * as path from "path";
-import { ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
-import { History, HistoryStatus } from "../../historyManager";
+import { TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
+import { History, HistoryManager, HistoryStatus } from "../../historyManager";
 import { Utils } from "../../utils";
 import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
+import JobTreeItem from "./job";
 
 export default class HistoryTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
     static contextValue = 'githubLocalActions.history';
     history: History;
 
     constructor(public workspaceFolder: WorkspaceFolder, history: History) {
-        super(`${history.name} #${history.count}`, TreeItemCollapsibleState.None);
+        super(`${history.name} #${history.count}`, TreeItemCollapsibleState.Collapsed);
         this.history = history;
 
         let endTime: string | undefined;
@@ -24,20 +25,7 @@ export default class HistoryTreeItem extends TreeItem implements GithubLocalActi
 
         this.description = totalDuration;
         this.contextValue = `${HistoryTreeItem.contextValue}_${history.status}`;
-        switch (history.status) {
-            case HistoryStatus.Running:
-                this.iconPath = new ThemeIcon('loading~spin');
-                break;
-            case HistoryStatus.Success:
-                this.iconPath = new ThemeIcon('pass', new ThemeColor('GitHubLocalActions.green'));
-                break;
-            case HistoryStatus.Failed:
-                this.iconPath = new ThemeIcon('error', new ThemeColor('GitHubLocalActions.red'));
-                break;
-            case HistoryStatus.Cancelled:
-                this.iconPath = new ThemeIcon('circle-slash', new ThemeColor('GitHubLocalActions.yellow'));
-                break;
-        }
+        this.iconPath = HistoryManager.statusToIcon(history.status);
         this.tooltip = `Name: ${history.name} #${history.count}\n` +
             `${history.commandArgs.extraHeader.map(header => `${header.key}: ${header.value}`).join('\n')}\n` +
             `Path: ${history.commandArgs.path}\n` +
@@ -46,14 +34,14 @@ export default class HistoryTreeItem extends TreeItem implements GithubLocalActi
             `Started: ${Utils.getDateString(history.date.start)}\n` +
             `Ended: ${endTime ? Utils.getDateString(endTime) : 'N/A'}\n` +
             `Total Duration: ${totalDuration ? totalDuration : 'N/A'}`;
-        this.command = {
-            title: 'Focus Task',
-            command: 'githubLocalActions.focusTask',
-            arguments: [this]
-        };
+        // this.command = {
+        //     title: 'Focus Task',
+        //     command: 'githubLocalActions.focusTask',
+        //     arguments: [this]
+        // };
     }
 
     async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
-        return [];
+        return this.history.jobs?.map(job => new JobTreeItem(this.workspaceFolder, job)) || [];
     }
 }

--- a/src/views/history/historyTreeDataProvider.ts
+++ b/src/views/history/historyTreeDataProvider.ts
@@ -31,8 +31,15 @@ export default class HistoryTreeDataProvider implements TreeDataProvider<GithubL
                 for (const terminal of terminals) {
                     if (terminal.creationOptions.name === `${historyTreeItem.history.name} #${historyTreeItem.history.count}`) {
                         terminal.show();
+                        return;
                     }
                 }
+
+                window.showErrorMessage(`${historyTreeItem.history.name} #${historyTreeItem.history.count} task is no longer open.`, 'View Output').then(async value => {
+                    if (value === 'View Output') {
+                        await commands.executeCommand('githubLocalActions.viewOutput', historyTreeItem);
+                    }
+                });
             }),
             commands.registerCommand('githubLocalActions.viewOutput', async (historyTreeItem: HistoryTreeItem) => {
                 await act.historyManager.viewOutput(historyTreeItem.history);

--- a/src/views/history/job.ts
+++ b/src/views/history/job.ts
@@ -1,0 +1,38 @@
+import { TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
+import { HistoryManager, HistoryStatus, Job } from "../../historyManager";
+import { Utils } from "../../utils";
+import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
+import StepTreeItem from "./step";
+
+export default class JobTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
+    static contextValue = 'githubLocalActions.job';
+    job: Job;
+
+    constructor(public workspaceFolder: WorkspaceFolder, job: Job) {
+        super(job.name, TreeItemCollapsibleState.Expanded);
+        this.job = job;
+
+        let endTime: string | undefined;
+        let totalDuration: string | undefined;
+        if (job.date.end) {
+            endTime = job.date.end;
+            totalDuration = Utils.getTimeDuration(job.date.start, endTime);
+        } else if (job.status === HistoryStatus.Running) {
+            endTime = new Date().toString();
+            totalDuration = Utils.getTimeDuration(job.date.start, endTime);
+        }
+
+        this.description = totalDuration;
+        this.contextValue = `${JobTreeItem.contextValue}_${job.status}`;
+        this.iconPath = HistoryManager.statusToIcon(job.status);
+        this.tooltip = `Name: ${job.name}\n` +
+            `Status: ${job.status}\n` +
+            `Started: ${Utils.getDateString(job.date.start)}\n` +
+            `Ended: ${endTime ? Utils.getDateString(endTime) : 'N/A'}\n` +
+            `Total Duration: ${totalDuration ? totalDuration : 'N/A'}`;
+    }
+
+    async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
+        return this.job.steps?.map(step => new StepTreeItem(this.workspaceFolder, step)) || [];
+    }
+}

--- a/src/views/history/step.ts
+++ b/src/views/history/step.ts
@@ -1,0 +1,37 @@
+import { TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
+import { HistoryManager, HistoryStatus, Step } from "../../historyManager";
+import { Utils } from "../../utils";
+import { GithubLocalActionsTreeItem } from "../githubLocalActionsTreeItem";
+
+export default class StepTreeItem extends TreeItem implements GithubLocalActionsTreeItem {
+    static contextValue = 'githubLocalActions.step';
+    step: Step;
+
+    constructor(public workspaceFolder: WorkspaceFolder, step: Step) {
+        super(step.name, TreeItemCollapsibleState.None);
+        this.step = step;
+
+        let endTime: string | undefined;
+        let totalDuration: string | undefined;
+        if (step.date.end) {
+            endTime = step.date.end;
+            totalDuration = Utils.getTimeDuration(step.date.start, endTime);
+        } else if (step.status === HistoryStatus.Running) {
+            endTime = new Date().toString();
+            totalDuration = Utils.getTimeDuration(step.date.start, endTime);
+        }
+
+        this.description = totalDuration;
+        this.contextValue = `${StepTreeItem.contextValue}_${step.status}`;
+        this.iconPath = HistoryManager.statusToIcon(step.status);
+        this.tooltip = `Name: ${step.name}\n` +
+            `Status: ${step.status}\n` +
+            `Started: ${Utils.getDateString(step.date.start)}\n` +
+            `Ended: ${endTime ? Utils.getDateString(endTime) : 'N/A'}\n` +
+            `Total Duration: ${totalDuration ? totalDuration : 'N/A'}`;
+    }
+
+    async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
+        return [];
+    }
+}

--- a/src/views/settings/settingsTreeDataProvider.ts
+++ b/src/views/settings/settingsTreeDataProvider.ts
@@ -307,9 +307,9 @@ export default class SettingsTreeDataProvider implements TreeDataProvider<Github
                 ];
 
                 options.forEach((option, index) => {
-                    options[index].label = options[index].label.slice(2)
+                    options[index].label = options[index].label.slice(2);
                     options[index].iconPath = new ThemeIcon('symbol-property');
-                })
+                });
 
                 const settings = await act.settingsManager.getSettings(optionsTreeItem.workspaceFolder, false);
                 const optionNames = settings.options.map(option => option.name);


### PR DESCRIPTION
### Changes
- [x] Add job and step level execution status
- [x] Fix job ID instead of job name being displayed
- [x] Fix displayed output when user's select `--json` flag
- [x] Make `Run Event` trigger separate tasks for each workflow so `-W` flag is always used
- [x] Add right-click action to `Focus Task` for history tree item to focus on the associated running task

Currently blocked by some missing JSONs in act itself: https://github.com/nektos/act/issues/2551

![image](https://github.com/user-attachments/assets/f85eb0c7-008b-4ae5-8a9d-afacb163ef26)
