### PR TITLE
step ids are strings

### DIFF
--- a/src/act.ts
+++ b/src/act.ts
@@ -445,7 +445,7 @@ export class Act {
                                         },
                                         steps: [
                                             {
-                                                id: -1, // Special id for setup job
+                                                id: "--setup-job", // Special id for setup job
                                                 name: 'Setup Job',
                                                 status: HistoryStatus.Running,
                                                 date: {
@@ -460,13 +460,13 @@ export class Act {
                                 const isCompleteJobStep = this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps!.length > 1;
                                 if (parsedMessage.stepID || isCompleteJobStep) {
                                     let stepName: string;
-                                    let stepId: number;
+                                    let stepId: string;
                                     if (!parsedMessage.stepID && isCompleteJobStep) {
                                         stepName = 'Complete Job';
-                                        stepId = -2; // Special Id for complete job
+                                        stepId = "--complete-job"; // Special Id for complete job
                                     } else {
                                         stepName = parsedMessage.stage !== 'Main' ? `${parsedMessage.stage} ${parsedMessage.step}` : parsedMessage.step;
-                                        stepId = parseInt(parsedMessage.stepID[0]);
+                                        stepId = parsedMessage.stepID[0];
                                     }
 
                                     if (this.historyManager.workspaceHistory[commandArgs.path][historyIndex].jobs![jobIndex].steps![0].status === HistoryStatus.Running) {

--- a/src/historyManager.ts
+++ b/src/historyManager.ts
@@ -29,7 +29,7 @@ export interface Job {
 }
 
 export interface Step {
-    id: number,
+    id: string,
     name: string,
     status: HistoryStatus,
     date: {


### PR DESCRIPTION
My cli shim currently exposed internal guids that are parsed as NaN otherwise, but still doesn't work well after fixing the json logger.

**Long json lines get wrapped in your code**


<img width="532" alt="image" src="https://github.com/user-attachments/assets/7e3cd6dc-eac7-4257-a62f-fbcb50d9578e">

Does your input reader has an overflow? The job with the question mark in the middle has a broken json split into two lines, my tool prints them always in one line
```
dotnet run --project /Users/christopher/Documents/ActionsAndPipelines/runner.server/src/Runner.Client --json --workflows ".github/workflows/main.yml" --job "test" --secret-file "" --var TEST=$PATH-batch --var-file "" --input-file "" --platform self-hosted=-self-hosted --eventpath "/Users/christopher/Documents/doc/payload.json" --actor bot --json

Starting Server...
The server is listening on http://[::]:52934 / http://192.168.178.146:52934
Starting 1 Runner...
First runner is listening for jobs
No default github.ref found
Couldn't retrieve github.sha
[.github/workflows/main.yml] Running: .github/workflows/main.yml
[.github/workflows/main.yml] Initialize Workflow Run 1
[.github/workflows/main.yml] Updated Workflow Name: Help
[test] Running: test
[test] Evaluate if
[test] Evaluating: success()
[test] Evaluating success:
[test] => true
[test] Result: true
[test] Evaluate strategy
[test] Prepare Job for execution
[test] Evaluate job name
[test] Evaluate job continueOnError
[test] Evaluate job timeoutMinutes
[test] Evaluate job cancelTimeoutMinutes
[test] Evaluate runs-on
[test] Queued Job: test (Hello World) for queue self-hosted
[test] Read Job from Queue: test (Hello World) assigned to Runner Name:4zejhvgq.3mh Labels:self-hosted
[test] Send Job to Runner: test (Hello World) for queue self-hosted assigned to Runner Name:4zejhvgq.3mh Labels:self-hosted
[test (Hello World)] Running: Set up job
[test (Hello World)] Current runner version: '0'
[test (Hello World)] Runner name: '4zejhvgq.3mh'
[test (Hello World)] Runner group name: 'Default'
[test (Hello World)] Machine name: 'Mac'
[test (Hello World)] Secret source: Actions
[test (Hello World)] Prepare workflow directory
[test (Hello World)] Prepare all required actions
[test (Hello World)] Getting action download info
[test (Hello World)] Download action repository 'actions/github-script@HEAD' (SHA:HEAD)
[test (Hello World)] Uses: Unknown/Unknown/.github/workflows/main.yml
[test (Hello World)] Complete job name: test (Hello World)
[test (Hello World)] Succeeded: Set up job
[test (Hello World)] Running: Run echo 'bot'
[test (Hello World)] ##[group]Run echo 'bot'
[test (Hello World)] [36;1mecho 'bot'[0m
[test (Hello World)] shell: /bin/bash -e {0}
[test (Hello World)] ##[endgroup]
[test (Hello World)] bot
[test (Hello World)] Succeeded: Run echo 'bot'
[test (Hello World)] Running: Run echo '/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch'
[test (Hello World)] ##[group]Run echo '/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch'
[test (Hello World)] [36;1mecho '/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch'[0m
[test (Hello World)] shell: /bin/bash -e {0}
[test (Hello World)] ##[endgroup]
[test (Hello World)] /usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch
{"dryrun":false,"workflowName":"Help","job":"test (Hello World)","jobID":"test","level":"info","matrix":{"ok":"Hello World"},"stepResult":"success","msg":"Succeeded: Run echo '/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch'","stage":"Main","step":"Run echo '/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/cod
ex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools-batch'","stepID":["80735ae6-f559-471c-aba0-d680ff6f7299"],"time":"2024-11-30T19:57:38.195743+01:00"}
[test (Hello World)] Running: Run echo ''
[test (Hello World)] ##[group]Run echo ''
[test (Hello World)] [36;1mecho ''[0m
[test (Hello World)] shell: /bin/bash -e {0}
[test (Hello World)] ##[endgroup]
[test (Hello World)] Succeeded: Run echo ''
[test (Hello World)] Running: Run actions/github-script@HEAD
[test (Hello World)] ##[group]Run actions/github-script@HEAD
[test (Hello World)] with:
[test (Hello World)]   script: console.log('Test 2024-11-27T18:41:43.2689480Z')
[test (Hello World)] console.log('Test 2024-11-27T18:41:43.2689480Z')
{"dryrun":false,"workflowName":"Help","job":"test (Hello World)","jobID":"test","level":"info","matrix":{"ok":"Hello World"},"msg":"","stage":"Main","step":"Run actions/github-script@HEAD","stepID":["037687d3-04bd-4e2a-9465-acace59ddd93"],"time":"2024-11-30T19:57:38.195887+01:00"}
[test (Hello World)]   github-token: none
[test (Hello World)]   debug: false
[test (Hello World)]   user-agent: actions/github-script
[test (Hello World)]   result-encoding: json
[test (Hello World)]   retries: 0
[test (Hello World)]   retry-exempt-status-codes: 400,401,403,404,422
[test (Hello World)] ##[endgroup]
[test (Hello World)] Test 2024-11-27T18:41:43.2689480Z
[test (Hello World)] Test 2024-11-27T18:41:43.2689480Z
[test (Hello World)] Succeeded: Run actions/github-script@HEAD
[test (Hello World)] Running: Run echo '
[test (Hello World)] ##[group]Run echo '
[test (Hello World)] [36;1mTest 2024-11-27T18:41:43.2689480Z'[0m
[test (Hello World)] [36;1mecho '[0m
{"dryrun":false,"workflowName":"Help","job":"test (Hello World)","jobID":"test","level":"info","matrix":{"ok":"Hello World"},"msg":"shell: /bin/bash -e {0}","stage":"Main","step":"Run echo '","stepID":["8d0cd994-4065-40ab-b5e2-fa9d674a444e"],"time":"2024-1
1-30T19:57:38.758909+01:00"}
[test (Hello World)] ##[endgroup]
[test (Hello World)] Test 2024-11-27T18:41:43.2689480Z
[test (Hello World)] Succeeded: Run echo '
[test (Hello World)] Running: Complete job
[test (Hello World)] Cleaning up orphan processes
[test (Hello World)] Succeeded: Complete job
[test (Hello World)] Job Completed with Status: Succeeded
Workflow 1 Completed with Status: Succeeded
All Workflows finished successfully
Stopped Runner
Stopped Server

Task exited with exit code 0.
```

BTW. my experimental vscode extension borrowed the log display formatting of the official extension so I have proper ansi colors instead of ESC chars in the log view