### PR TITLE
Add keybinding to run workflow in active editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,13 @@
         "when": "githubLocalActions:noSettings && workspaceFolderCount > 0"
       }
     ],
+    "keybindings": [
+      {
+        "command": "githubLocalActions.runWorkflow",
+        "key": "ctrl+g",
+        "mac": "cmd+g"
+      }
+    ],
     "commands": [
       {
         "category": "GitHub Local Actions",

--- a/src/act.ts
+++ b/src/act.ts
@@ -267,7 +267,7 @@ export class Act {
             path: workspaceFolder.uri.fsPath,
             workflow: workflow,
             options: [
-                `${Option.Workflows} ".github/workflows/${path.parse(workflow.uri.fsPath).base}"`
+                `${Option.Workflows} "${WorkflowsManager.WORKFLOWS_DIRECTORY}/${path.parse(workflow.uri.fsPath).base}"`
             ],
             name: workflow.name,
             extraHeader: [
@@ -281,7 +281,7 @@ export class Act {
             path: workspaceFolder.uri.fsPath,
             workflow: workflow,
             options: [
-                `${Option.Workflows} ".github/workflows/${path.parse(workflow.uri.fsPath).base}"`,
+                `${Option.Workflows} "${WorkflowsManager.WORKFLOWS_DIRECTORY}/${path.parse(workflow.uri.fsPath).base}"`,
                 `${Option.Job} "${job.id}"`
             ],
             name: `${workflow.name}/${job.name}`,
@@ -304,7 +304,7 @@ export class Act {
                         path: workspaceFolder.uri.fsPath,
                         workflow: workflow,
                         options: [
-                            `${event} ${Option.Workflows} ".github/workflows/${path.parse(workflow.uri.fsPath).base}"`
+                            `${event} ${Option.Workflows} "${WorkflowsManager.WORKFLOWS_DIRECTORY}/${path.parse(workflow.uri.fsPath).base}"`
                         ],
                         name: `${workflow.name} (${event})`,
                         extraHeader: [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import HistoryTreeDataProvider from './views/history/historyTreeDataProvider';
 import SettingTreeItem from './views/settings/setting';
 import SettingsTreeDataProvider from './views/settings/settingsTreeDataProvider';
 import WorkflowsTreeDataProvider from './views/workflows/workflowsTreeDataProvider';
+import { WorkflowsManager } from './workflowsManager';
 
 export let act: Act;
 export let componentsTreeDataProvider: ComponentsTreeDataProvider;
@@ -36,7 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	// Create file watcher
-	const workflowsFileWatcher = workspace.createFileSystemWatcher('**/.github/workflows/*.{yml,yaml}');
+	const workflowsFileWatcher = workspace.createFileSystemWatcher(`**/${WorkflowsManager.WORKFLOWS_DIRECTORY}/*.{${WorkflowsManager.YML_EXTENSION},${WorkflowsManager.YAML_EXTENSION}}`);
 	workflowsFileWatcher.onDidCreate(() => {
 		workflowsTreeDataProvider.refresh();
 		settingsTreeDataProvider.refresh();

--- a/src/workflowsManager.ts
+++ b/src/workflowsManager.ts
@@ -17,10 +17,14 @@ export interface Job {
 }
 
 export class WorkflowsManager {
+  static WORKFLOWS_DIRECTORY: string = '.github/workflows';
+  static YAML_EXTENSION: string = 'yaml';
+  static YML_EXTENSION: string = 'yml';
+
   async getWorkflows(workspaceFolder: WorkspaceFolder): Promise<Workflow[]> {
     const workflows: Workflow[] = [];
 
-    const workflowFileUris = await workspace.findFiles(new RelativePattern(workspaceFolder, `.github/workflows/*.{yml,yaml}`));
+    const workflowFileUris = await workspace.findFiles(new RelativePattern(workspaceFolder, `${WorkflowsManager.WORKFLOWS_DIRECTORY}/*.{${WorkflowsManager.YAML_EXTENSION},${WorkflowsManager.YML_EXTENSION}}`));
     for await (const workflowFileUri of workflowFileUris) {
       let yamlContent: any | undefined;
 


### PR DESCRIPTION
### ✍ Changes
Add `ctrl+g` (Windows) and `cmd+g` (MacOS) keybinding to run workflow in the active editor.

### 📋 Checklist
<!-- Complete the checklist -->
- [x] I tested my changes
- [x] I updated relevant documentation (https://github.com/SanjulaGanepola/github-local-actions-docs/pull/3)