### PR TITLE
Fix handling of variables, inputs, platforms, and options with spaces

### DIFF
--- a/src/act.ts
+++ b/src/act.ts
@@ -404,11 +404,11 @@ export class Act {
         const userOptions: string[] = [
             ...settings.secrets.map(secret => `${Option.Secret} ${secret.key}`),
             (settings.secretFiles.length > 0 ? `${Option.SecretFile} "${settings.secretFiles[0].path}"` : `${Option.SecretFile} ""`),
-            ...settings.variables.map(variable => `${Option.Var} "${variable.key}=${variable.value}"`),
+            ...settings.variables.map(variable => `${Option.Var} ${variable.key}="${variable.value}"`),
             (settings.variableFiles.length > 0 ? `${Option.VarFile} "${settings.variableFiles[0].path}"` : `${Option.VarFile} ""`),
-            ...settings.inputs.map(input => `${Option.Input} "${input.key}=${input.value}"`),
+            ...settings.inputs.map(input => `${Option.Input} ${input.key}="${input.value}"`),
             (settings.inputFiles.length > 0 ? `${Option.InputFile} "${settings.inputFiles[0].path}"` : `${Option.InputFile} ""`),
-            ...settings.runners.map(runner => `${Option.Platform} "${runner.key}=${runner.value}"`),
+            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}="${runner.value}"`),
             (settings.payloadFiles.length > 0 ? `${Option.EventPath} "${settings.payloadFiles[0].path}"` : `${Option.EventPath} ""`),
             ...settings.options.map(option => option.path ? `--${option.name} "${option.path}"` : `--${option.name}`)
         ];

--- a/src/act.ts
+++ b/src/act.ts
@@ -404,13 +404,13 @@ export class Act {
         const userOptions: string[] = [
             ...settings.secrets.map(secret => `${Option.Secret} ${secret.key}`),
             (settings.secretFiles.length > 0 ? `${Option.SecretFile} "${settings.secretFiles[0].path}"` : `${Option.SecretFile} ""`),
-            ...settings.variables.map(variable => `${Option.Var} ${variable.key}=${variable.value}`),
+            ...settings.variables.map(variable => `${Option.Var} "${variable.key}=${variable.value}"`),
             (settings.variableFiles.length > 0 ? `${Option.VarFile} "${settings.variableFiles[0].path}"` : `${Option.VarFile} ""`),
-            ...settings.inputs.map(input => `${Option.Input} ${input.key}=${input.value}`),
+            ...settings.inputs.map(input => `${Option.Input} "${input.key}=${input.value}"`),
             (settings.inputFiles.length > 0 ? `${Option.InputFile} "${settings.inputFiles[0].path}"` : `${Option.InputFile} ""`),
-            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}=${runner.value}`),
+            ...settings.runners.map(runner => `${Option.Platform} "${runner.key}=${runner.value}"`),
             (settings.payloadFiles.length > 0 ? `${Option.EventPath} "${settings.payloadFiles[0].path}"` : `${Option.EventPath} ""`),
-            ...settings.options.map(option => option.path ? `--${option.name} ${option.path}` : `--${option.name}`)
+            ...settings.options.map(option => option.path ? `--${option.name} "${option.path}"` : `--${option.name}`)
         ];
 
         const command = `${actCommand} ${Option.Json} ${Option.Verbose} ${commandArgs.options.join(' ')} ${userOptions.join(' ')}`;

--- a/src/act.ts
+++ b/src/act.ts
@@ -10,6 +10,7 @@ import { HistoryManager, HistoryStatus } from './historyManager';
 import { SecretManager } from "./secretManager";
 import { SettingsManager } from './settingsManager';
 import { StorageKey, StorageManager } from './storageManager';
+import { Utils } from "./utils";
 import { Job, Workflow, WorkflowsManager } from "./workflowsManager";
 
 export enum Event {
@@ -404,13 +405,13 @@ export class Act {
         const userOptions: string[] = [
             ...settings.secrets.map(secret => `${Option.Secret} ${secret.key}`),
             (settings.secretFiles.length > 0 ? `${Option.SecretFile} "${settings.secretFiles[0].path}"` : `${Option.SecretFile} ""`),
-            ...settings.variables.map(variable => `${Option.Var} ${variable.key}="${variable.value}"`),
+            ...settings.variables.map(variable => `${Option.Var} ${variable.key}="${Utils.escapeDoubleQuotes(variable.value)}"`),
             (settings.variableFiles.length > 0 ? `${Option.VarFile} "${settings.variableFiles[0].path}"` : `${Option.VarFile} ""`),
-            ...settings.inputs.map(input => `${Option.Input} ${input.key}="${input.value}"`),
+            ...settings.inputs.map(input => `${Option.Input} ${input.key}="${Utils.escapeDoubleQuotes(input.value)}"`),
             (settings.inputFiles.length > 0 ? `${Option.InputFile} "${settings.inputFiles[0].path}"` : `${Option.InputFile} ""`),
-            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}="${runner.value}"`),
+            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}="${Utils.escapeDoubleQuotes(runner.value)}"`),
             (settings.payloadFiles.length > 0 ? `${Option.EventPath} "${settings.payloadFiles[0].path}"` : `${Option.EventPath} ""`),
-            ...settings.options.map(option => option.path ? `--${option.name} "${option.path}"` : `--${option.name}`)
+            ...settings.options.map(option => option.path ? `--${option.name} "${Utils.escapeDoubleQuotes(option.path)}"` : `--${option.name}`)
         ];
 
         const command = `${actCommand} ${Option.Json} ${Option.Verbose} ${commandArgs.options.join(' ')} ${userOptions.join(' ')}`;

--- a/src/act.ts
+++ b/src/act.ts
@@ -405,13 +405,13 @@ export class Act {
         const userOptions: string[] = [
             ...settings.secrets.map(secret => `${Option.Secret} ${secret.key}`),
             (settings.secretFiles.length > 0 ? `${Option.SecretFile} "${settings.secretFiles[0].path}"` : `${Option.SecretFile} ""`),
-            ...settings.variables.map(variable => `${Option.Var} ${variable.key}="${Utils.escapeDoubleQuotes(variable.value)}"`),
+            ...settings.variables.map(variable => `${Option.Var} ${variable.key}="${Utils.escapeSpecialCharacters(variable.value)}"`),
             (settings.variableFiles.length > 0 ? `${Option.VarFile} "${settings.variableFiles[0].path}"` : `${Option.VarFile} ""`),
-            ...settings.inputs.map(input => `${Option.Input} ${input.key}="${Utils.escapeDoubleQuotes(input.value)}"`),
+            ...settings.inputs.map(input => `${Option.Input} ${input.key}="${Utils.escapeSpecialCharacters(input.value)}"`),
             (settings.inputFiles.length > 0 ? `${Option.InputFile} "${settings.inputFiles[0].path}"` : `${Option.InputFile} ""`),
-            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}="${Utils.escapeDoubleQuotes(runner.value)}"`),
+            ...settings.runners.map(runner => `${Option.Platform} ${runner.key}="${Utils.escapeSpecialCharacters(runner.value)}"`),
             (settings.payloadFiles.length > 0 ? `${Option.EventPath} "${settings.payloadFiles[0].path}"` : `${Option.EventPath} ""`),
-            ...settings.options.map(option => option.path ? `--${option.name} "${Utils.escapeDoubleQuotes(option.path)}"` : `--${option.name}`)
+            ...settings.options.map(option => option.path ? `--${option.name} "${Utils.escapeSpecialCharacters(option.path)}"` : `--${option.name}`)
         ];
 
         const command = `${actCommand} ${Option.Json} ${Option.Verbose} ${commandArgs.options.join(' ')} ${userOptions.join(' ')}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,9 +58,9 @@ export namespace Utils {
     }
 
     /**
-     * Replaces all double quotes with an escaped double quotes.
+     * Escape all backslashes and double quotes. 
      */
-    export function escapeDoubleQuotes(input: string): string {
+    export function escapeSpecialCharacters(input: string): string {
         return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,4 +56,11 @@ export namespace Utils {
             }
         }
     }
+
+    /**
+     * Replaces all double quotes with an escaped double quotes.
+     */
+    export function escapeDoubleQuotes(input: string): string {
+        return input.replace(/"/g, '\\"');
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,6 @@ export namespace Utils {
      * Replaces all double quotes with an escaped double quotes.
      */
     export function escapeDoubleQuotes(input: string): string {
-        return input.replace(/"/g, '\\"');
+        return input.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     }
 }


### PR DESCRIPTION
### ✍ Changes
- Wrap variables, inputs, platforms, and options with double quotes to fix issues with spaces

I tested this on Windows, but will need some help with testing on Linux and MacOS.

### 📋 Checklist
<!-- Complete the checklist -->
- [x] I tested my changes
- [ ] I updated relevant documentation
- [ ] I added myself to the [contributors' list](https://github.com/SanjulaGanepola/github-local-actions/blob/main/CONTRIBUTING.md#contributors)