### PR TITLE
UX Use add-file icon for adding files instead of add

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
         "category": "GitHub Local Actions",
         "command": "githubLocalActions.createSecretFile",
         "title": "Create Secret File",
-        "icon": "$(add)"
+        "icon": "$(file-add)"
       },
       {
         "category": "GitHub Local Actions",
@@ -286,7 +286,7 @@
         "category": "GitHub Local Actions",
         "command": "githubLocalActions.createVariableFile",
         "title": "Create Variable File",
-        "icon": "$(add)"
+        "icon": "$(file-add)"
       },
       {
         "category": "GitHub Local Actions",
@@ -304,7 +304,7 @@
         "category": "GitHub Local Actions",
         "command": "githubLocalActions.createInputFile",
         "title": "Create Input File",
-        "icon": "$(add)"
+        "icon": "$(file-add)"
       },
       {
         "category": "GitHub Local Actions",
@@ -316,7 +316,7 @@
         "category": "GitHub Local Actions",
         "command": "githubLocalActions.createPayloadFile",
         "title": "Create Payload File",
-        "icon": "$(add)"
+        "icon": "$(file-add)"
       },
       {
         "category": "GitHub Local Actions",


### PR DESCRIPTION
I'm not a UX expert, but this confused me a bit

### ✍ Changes
Don't require to hover the `+` icon to realize this creates a file and instead of allowing to add an entry
![image](https://github.com/user-attachments/assets/f4fd3f80-d795-4a6a-942b-b7f74afba6c0)

Free the place to add a new `$(add)` that adds custom var/secret names.

### 📋 Checklist
<!-- Complete the checklist -->
- [x] I tested my changes
- [ ] I updated relevant documentation
- [ ] I added myself to the [contributors' list](https://github.com/SanjulaGanepola/github-local-actions/blob/main/CONTRIBUTING.md#contributors)