### PR TITLE
Add support for running specific events on workflows and jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
 # Change Log
 
-All notable changes to the "github-local-actions" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
-### Added
-
-- Added support for running specific events on workflows and jobs
-
-## [1.0.0]
-
-- Initial release
+All notable changes to the "github-local-actions" extension will be documented in the [GitHub release notes](https://github.com/SanjulaGanepola/github-local-actions/releases).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "github-local-actions" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Added
+
+- Added support for running specific events on workflows and jobs
+
 ## [1.0.0]
 
 - Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,5 +25,6 @@ Thanks so much to everyone [who has contributed](https://github.com/SanjulaGanep
 
 * [@SanjulaGanepola](https://github.com/SanjulaGanepola)
 * [@ChristopherHX](https://github.com/ChristopherHX)
+* [@a11rew](https://github.com/a11rew)
 
 Want to see your name on this list? Join us and contribute!

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ The `Workflows` view is where you can manage and run workflows locally. You have
 5. **Run Workflow Event**: Run a specific event on a workflow.
 6. **Run Job Event**: Run a specific event on a job.
 
-You can access these commands via:
-
-* Use the buttons in the Workflows view header for workspace-wide commands (like "Run All Workflows")
-* Inline buttons that appear when hovering over workflows and jobs
-* Right-click context menu for workflows and jobs
-
 ![Workflows View](https://raw.githubusercontent.com/SanjulaGanepola/github-local-actions/main/images/workflows-view.png)
 
 ## History

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ The `Workflows` view is where you can manage and run workflows locally. You have
 2. **Run Single Workflow**: Run a single workflow in the workspace.
 3. **Run Job**: Run a specific job in a workflow.
 4. **Run Event**: Run multiple workflows using a [GitHub event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows).
+5. **Run Workflow Event**: Run a specific event on a workflow.
+6. **Run Job Event**: Run a specific event on a job.
+
+You can access these commands via:
+
+* Use the buttons in the Workflows view header for workspace-wide commands (like "Run All Workflows")
+* Inline buttons that appear when hovering over workflows and jobs
+* Right-click context menu for workflows and jobs
 
 ![Workflows View](https://raw.githubusercontent.com/SanjulaGanepola/github-local-actions/main/images/workflows-view.png)
 

--- a/package.json
+++ b/package.json
@@ -184,20 +184,8 @@
       },
       {
         "category": "GitHub Local Actions",
-        "command": "githubLocalActions.openWorkflow",
-        "title": "Open Workflow",
-        "icon": "$(go-to-file)"
-      },
-      {
-        "category": "GitHub Local Actions",
         "command": "githubLocalActions.runWorkflow",
         "title": "Run Workflow",
-        "icon": "$(debug-start)"
-      },
-      {
-        "category": "GitHub Local Actions",
-        "command": "githubLocalActions.runJob",
-        "title": "Run Job",
         "icon": "$(debug-start)"
       },
       {
@@ -205,6 +193,18 @@
         "command": "githubLocalActions.runWorkflowEvent",
         "title": "Run Workflow with Event",
         "icon": "$(symbol-event)"
+      },
+      {
+        "category": "GitHub Local Actions",
+        "command": "githubLocalActions.openWorkflow",
+        "title": "Open Workflow",
+        "icon": "$(go-to-file)"
+      },
+      {
+        "category": "GitHub Local Actions",
+        "command": "githubLocalActions.runJob",
+        "title": "Run Job",
+        "icon": "$(debug-start)"
       },
       {
         "category": "GitHub Local Actions",
@@ -430,19 +430,19 @@
           "when": "never"
         },
         {
-          "command": "githubLocalActions.openWorkflow",
-          "when": "never"
-        },
-        {
           "command": "githubLocalActions.runWorkflow",
           "when": "never"
         },
         {
-          "command": "githubLocalActions.runJob",
+          "command": "githubLocalActions.runWorkflowEvent",
           "when": "never"
         },
         {
-          "command": "githubLocalActions.runWorkflowEvent",
+          "command": "githubLocalActions.openWorkflow",
+          "when": "never"
+        },
+        {
+          "command": "githubLocalActions.runJob",
           "when": "never"
         },
         {
@@ -650,27 +650,32 @@
           "group": "inline@1"
         },
         {
-          "command": "githubLocalActions.openWorkflow",
+          "command": "githubLocalActions.runWorkflow",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
           "group": "inline@0"
         },
         {
           "command": "githubLocalActions.runWorkflow",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
+          "group": "workflows@0"
+        },
+        {
+          "command": "githubLocalActions.runWorkflowEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
           "group": "inline@1"
         },
         {
           "command": "githubLocalActions.runWorkflowEvent",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
-          "group": "inline@2"
-        },
-        {
-          "command": "githubLocalActions.runWorkflow",
-          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
           "group": "workflows@1"
         },
         {
-          "command": "githubLocalActions.runWorkflowEvent",
+          "command": "githubLocalActions.openWorkflow",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
+          "group": "inline@2"
+        },
+        {
+          "command": "githubLocalActions.openWorkflow",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
           "group": "workflows@2"
         },
@@ -680,14 +685,14 @@
           "group": "inline@0"
         },
         {
-          "command": "githubLocalActions.runJobEvent",
-          "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
-          "group": "inline@1"
-        },
-        {
           "command": "githubLocalActions.runJob",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
           "group": "jobs@0"
+        },
+        {
+          "command": "githubLocalActions.runJobEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
+          "group": "inline@1"
         },
         {
           "command": "githubLocalActions.runJobEvent",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,18 @@
       },
       {
         "category": "GitHub Local Actions",
+        "command": "githubLocalActions.runWorkflowEvent",
+        "title": "Run Workflow with Event",
+        "icon": "$(symbol-event)"
+      },
+      {
+        "category": "GitHub Local Actions",
+        "command": "githubLocalActions.runJobEvent",
+        "title": "Run Job with Event",
+        "icon": "$(symbol-event)"
+      },
+      {
+        "category": "GitHub Local Actions",
         "command": "githubLocalActions.clearAll",
         "title": "Clear All",
         "enablement": "!githubLocalActions:noHistory && !githubLocalActions:isRunning && !githubLocalActions:noWorkflows && workspaceFolderCount > 0",
@@ -430,6 +442,14 @@
           "when": "never"
         },
         {
+          "command": "githubLocalActions.runWorkflowEvent",
+          "when": "never"
+        },
+        {
+          "command": "githubLocalActions.runJobEvent",
+          "when": "never"
+        },
+        {
           "command": "githubLocalActions.clearAll",
           "when": "never"
         },
@@ -640,9 +660,39 @@
           "group": "inline@1"
         },
         {
+          "command": "githubLocalActions.runWorkflowEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
+          "group": "inline@2"
+        },
+        {
+          "command": "githubLocalActions.runWorkflow",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
+          "group": "workflows@1"
+        },
+        {
+          "command": "githubLocalActions.runWorkflowEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.workflow.*/",
+          "group": "workflows@2"
+        },
+        {
           "command": "githubLocalActions.runJob",
           "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
           "group": "inline@0"
+        },
+        {
+          "command": "githubLocalActions.runJobEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
+          "group": "inline@1"
+        },
+        {
+          "command": "githubLocalActions.runJob",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
+          "group": "jobs@0"
+        },
+        {
+          "command": "githubLocalActions.runJobEvent",
+          "when": "view == workflows && viewItem =~ /^githubLocalActions.job.*/",
+          "group": "jobs@1"
         },
         {
           "command": "githubLocalActions.clearAll",

--- a/src/views/workflows/workflowsTreeDataProvider.ts
+++ b/src/views/workflows/workflowsTreeDataProvider.ts
@@ -109,7 +109,7 @@ export default class WorkflowsTreeDataProvider implements TreeDataProvider<Githu
                 });
 
                 if (event) {
-                    await act.runEvent(workflowTreeItem.workspaceFolder, event as Event, workflowTreeItem.workflow);
+                    await act.runEvent(workflowTreeItem.workspaceFolder, event as Event, { workflow: workflowTreeItem.workflow });
                 }
             }),
             commands.registerCommand('githubLocalActions.runJobEvent', async (jobTreeItem: JobTreeItem) => {
@@ -127,7 +127,7 @@ export default class WorkflowsTreeDataProvider implements TreeDataProvider<Githu
                 });
 
                 if (event) {
-                    await act.runEvent(jobTreeItem.workspaceFolder, event as Event, jobTreeItem.workflow, jobTreeItem.job);
+                    await act.runEvent(jobTreeItem.workspaceFolder, event as Event, { workflow: jobTreeItem.workflow, job: jobTreeItem.job });
                 }
             })
         );

--- a/src/views/workflows/workflowsTreeDataProvider.ts
+++ b/src/views/workflows/workflowsTreeDataProvider.ts
@@ -98,7 +98,7 @@ export default class WorkflowsTreeDataProvider implements TreeDataProvider<Githu
                 // Filter to only events that are registered on the workflow
                 const registeredEventsOnWorkflow = Object.keys(workflowTreeItem.workflow.yaml.on);
 
-                if (registeredEventsOnWorkflow.length !== 0) {
+                if (registeredEventsOnWorkflow.length === 0) {
                     window.showErrorMessage(`No events registered on the workflow (${workflowTreeItem.workflow.name}). Add an event to the \`on\` section of the workflow to trigger it.`);
                     return;
                 }
@@ -116,7 +116,7 @@ export default class WorkflowsTreeDataProvider implements TreeDataProvider<Githu
                 // Filter to only events that are registered on the job's parent workflow
                 const registeredEventsOnJobParentWorkflow = Object.keys(jobTreeItem.workflow.yaml.on);
 
-                if (registeredEventsOnJobParentWorkflow.length !== 0) {
+                if (registeredEventsOnJobParentWorkflow.length === 0) {
                     window.showErrorMessage(`No events registered on the workflow (${jobTreeItem.workflow.name}). Add an event to the \`on\` section of the workflow to trigger it.`);
                     return;
                 }

--- a/src/views/workflows/workflowsTreeDataProvider.ts
+++ b/src/views/workflows/workflowsTreeDataProvider.ts
@@ -93,6 +93,42 @@ export default class WorkflowsTreeDataProvider implements TreeDataProvider<Githu
             }),
             commands.registerCommand('githubLocalActions.runJob', async (jobTreeItem: JobTreeItem) => {
                 await act.runJob(jobTreeItem.workspaceFolder, jobTreeItem.workflow, jobTreeItem.job);
+            }),
+            commands.registerCommand('githubLocalActions.runWorkflowEvent', async (workflowTreeItem: WorkflowTreeItem) => {
+                // Filter to only events that are registered on the workflow
+                const registeredEventsOnWorkflow = Object.keys(workflowTreeItem.workflow.yaml.on);
+
+                if (registeredEventsOnWorkflow.length !== 0) {
+                    window.showErrorMessage(`No events registered on the workflow (${workflowTreeItem.workflow.name}). Add an event to the \`on\` section of the workflow to trigger it.`);
+                    return;
+                }
+
+                const event = await window.showQuickPick(registeredEventsOnWorkflow, {
+                    title: 'Select the event to run',
+                    placeHolder: 'Event',
+                });
+
+                if (event) {
+                    await act.runEvent(workflowTreeItem.workspaceFolder, event as Event, workflowTreeItem.workflow);
+                }
+            }),
+            commands.registerCommand('githubLocalActions.runJobEvent', async (jobTreeItem: JobTreeItem) => {
+                // Filter to only events that are registered on the job's parent workflow
+                const registeredEventsOnJobParentWorkflow = Object.keys(jobTreeItem.workflow.yaml.on);
+
+                if (registeredEventsOnJobParentWorkflow.length !== 0) {
+                    window.showErrorMessage(`No events registered on the workflow (${jobTreeItem.workflow.name}). Add an event to the \`on\` section of the workflow to trigger it.`);
+                    return;
+                }
+
+                const event = await window.showQuickPick(registeredEventsOnJobParentWorkflow, {
+                    title: 'Select the event to run',
+                    placeHolder: 'Event'
+                });
+
+                if (event) {
+                    await act.runEvent(jobTreeItem.workspaceFolder, event as Event, jobTreeItem.workflow, jobTreeItem.job);
+                }
             })
         );
     }


### PR DESCRIPTION
### ✍ Changes
Instead of triggering all workflows in the workspace when running events, this adds support for running events on only specific workflows or jobs.

- Adds inline "Run Workflow with Event" and "Run Job with Event" button for triggering runs with specific events
- Added "Run Workflow with Event" and "Run Job with Event" right click context menu options to jobs and workflows in the workflow list

Fixes #185 
Documented: https://github.com/SanjulaGanepola/github-local-actions-docs/pull/11

### What this looks like

https://github.com/user-attachments/assets/0fc6c313-1678-4694-9b8f-a90faa398c75


### 📋 Checklist
<!-- Complete the checklist -->
- [x] I tested my changes
- [x] I updated relevant documentation
- [x] I added myself to the [contributors' list](https://github.com/SanjulaGanepola/github-local-actions/blob/main/CONTRIBUTING.md#contributors)