### PR TITLE
feat: storageManager.ts - Write to filesystem for non-secret StorageKey values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,5 +26,6 @@ Thanks so much to everyone [who has contributed](https://github.com/SanjulaGanep
 * [@SanjulaGanepola](https://github.com/SanjulaGanepola)
 * [@ChristopherHX](https://github.com/ChristopherHX)
 * [@a11rew](https://github.com/a11rew)
+* [@atoko](https://github.com/atoko)
 
 Want to see your name on this list? Join us and contribute!

--- a/src/issueHandler.ts
+++ b/src/issueHandler.ts
@@ -118,8 +118,8 @@ export namespace IssueHandler {
                             });
                         }
 
-                        const workflowHistory = act.historyManager.workspaceHistory[workspaceFolder.uri.fsPath]?.filter(history => history.commandArgs.workflow?.uri.fsPath === workflow.uri.fsPath);
-                        if (workflowHistory && workflowHistory.length > 0) {
+                        const workflowHistory = ((await act.historyManager.getWorkspaceHistory())[workspaceFolder.uri.fsPath] ?? []).filter(history => history.commandArgs.workflow?.uri.fsPath === workflow.uri.fsPath);
+                        if (workflowHistory.length > 0) {
                             // Get last act command
                             const settings = await act.settingsManager.getSettings(workspaceFolder, true);
                             const history = workflowHistory[workflowHistory.length - 1];

--- a/src/settingsManager.ts
+++ b/src/settingsManager.ts
@@ -124,7 +124,7 @@ export class SettingsManager {
             }
         }
 
-        const existingSettings = this.storageManager.get<{ [path: string]: Setting[] }>(storageKey) || {};
+        const existingSettings = await this.storageManager.get<{ [path: string]: Setting[] }>(storageKey) || {};
         if (existingSettings[workspaceFolder.uri.fsPath]) {
             for (const [index, setting] of settings.entries()) {
                 const existingSetting = existingSettings[workspaceFolder.uri.fsPath].find(existingSetting => existingSetting.key === setting.key);
@@ -154,7 +154,7 @@ export class SettingsManager {
     }
 
     async getCustomSettings(workspaceFolder: WorkspaceFolder, storageKey: StorageKey): Promise<CustomSetting[]> {
-        const existingCustomSettings = this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
+        const existingCustomSettings = await this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
         return existingCustomSettings[workspaceFolder.uri.fsPath] || [];
     }
 
@@ -233,7 +233,7 @@ export class SettingsManager {
     }
 
     async editCustomSetting(workspaceFolder: WorkspaceFolder, newCustomSetting: CustomSetting, storageKey: StorageKey, forceAppend: boolean = false) {
-        const existingCustomSettings = this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
+        const existingCustomSettings = await this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
         if (existingCustomSettings[workspaceFolder.uri.fsPath]) {
             const index = existingCustomSettings[workspaceFolder.uri.fsPath]
                 .findIndex(customSetting =>
@@ -254,7 +254,7 @@ export class SettingsManager {
     }
 
     async removeCustomSetting(workspaceFolder: WorkspaceFolder, existingCustomSetting: CustomSetting, storageKey: StorageKey) {
-        const existingCustomSettings = this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
+        const existingCustomSettings = await this.storageManager.get<{ [path: string]: CustomSetting[] }>(storageKey) || {};
         if (existingCustomSettings[workspaceFolder.uri.fsPath]) {
             const index = existingCustomSettings[workspaceFolder.uri.fsPath].findIndex(customSetting =>
                 storageKey === StorageKey.Options ?
@@ -289,7 +289,7 @@ export class SettingsManager {
             newSetting.value = '';
         }
 
-        const existingSettings = this.storageManager.get<{ [path: string]: Setting[] }>(storageKey) || {};
+        const existingSettings = await this.storageManager.get<{ [path: string]: Setting[] }>(storageKey) || {};
         if (existingSettings[workspaceFolder.uri.fsPath]) {
             const index = existingSettings[workspaceFolder.uri.fsPath].findIndex(setting => setting.key === newSetting.key);
             if (index > -1) {

--- a/src/views/history/historyTreeDataProvider.ts
+++ b/src/views/history/historyTreeDataProvider.ts
@@ -87,18 +87,18 @@ export default class HistoryTreeDataProvider implements TreeDataProvider<GithubL
                 if (workspaceFolders.length === 1) {
                     items.push(...await new WorkspaceFolderHistoryTreeItem(workspaceFolders[0]).getChildren());
 
-                    const workspaceHistory = act.historyManager.workspaceHistory[workspaceFolders[0].uri.fsPath];
-                    if (workspaceHistory && workspaceHistory.length > 0) {
-                        isRunning = act.historyManager.workspaceHistory[workspaceFolders[0].uri.fsPath].find(workspaceHistory => workspaceHistory.status === HistoryStatus.Running) !== undefined;
+                    const workspaceHistory = (await act.historyManager.getWorkspaceHistory())[workspaceFolders[0].uri.fsPath] ?? [];
+                    if (workspaceHistory.length > 0) {
+                        isRunning = workspaceHistory.find(workspaceHistory => workspaceHistory.status === HistoryStatus.Running) !== undefined;
                         noHistory = false;
                     }
                 } else if (workspaceFolders.length > 1) {
                     for (const workspaceFolder of workspaceFolders) {
                         items.push(new WorkspaceFolderHistoryTreeItem(workspaceFolder));
 
-                        const workspaceHistory = act.historyManager.workspaceHistory[workspaceFolder.uri.fsPath];
-                        if (workspaceHistory && workspaceHistory.length > 0) {
-                            isRunning = act.historyManager.workspaceHistory[workspaceFolder.uri.fsPath].find(workspaceHistory => workspaceHistory.status === HistoryStatus.Running) !== undefined;
+                        const workspaceHistory = (await act.historyManager.getWorkspaceHistory())[workspaceFolder.uri.fsPath] ?? [];
+                        if (workspaceHistory.length > 0) {
+                            isRunning = workspaceHistory.find(workspaceHistory => workspaceHistory.status === HistoryStatus.Running) !== undefined;
                             noHistory = false;
                         }
                     }

--- a/src/views/history/workspaceFolderHistory.ts
+++ b/src/views/history/workspaceFolderHistory.ts
@@ -15,7 +15,7 @@ export default class WorkspaceFolderHistoryTreeItem extends TreeItem implements 
     async getChildren(): Promise<GithubLocalActionsTreeItem[]> {
         const items: GithubLocalActionsTreeItem[] = [];
 
-        const workspaceHistory = act.historyManager.workspaceHistory[this.workspaceFolder.uri.fsPath];
+        const workspaceHistory = (await act.historyManager.getWorkspaceHistory())[this.workspaceFolder.uri.fsPath];
         if (workspaceHistory) {
             for (const history of workspaceHistory.slice().reverse()) {
                 items.push(new HistoryTreeItem(this.workspaceFolder, history));


### PR DESCRIPTION
### ✍ Changes
This PR changes storageManager as described in #173 -- Settings will be stored in either `context.storageUri` or `context.globalStorageUri`, depending on if a workspace is loaded.

Each StorageKey will save to it's own json file matching the keyname + `.json` in the vscode-provided storage folder. If the given StorageKey contains "secret", we revert back to `globalState`.

### 📋 Checklist
<!-- Complete the checklist -->
- [ ] I tested my changes
- [ ] I updated relevant documentation
- [x] I added myself to the [contributors' list](https://github.com/SanjulaGanepola/github-local-actions/blob/main/CONTRIBUTING.md#contributors)