### PR TITLE
Get Setting[] from `workflow.yaml` object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,18 @@ No contribution is too small—every bit helps! If you're unsure where to start,
 1. Install [VS Code](https://code.visualstudio.com/download) and [Node.js](https://nodejs.org/en/download/package-manager).
 2. Create a [fork](https://github.com/SanjulaGanepola/github-local-actions/fork) of this repository.
 3. Clone your fork.
+
    ```sh
    git clone https://github.com/your-username/github-local-actions.git
    cd github-local-actions
    ```
+
 4. Install all dependencies.
+
     ```sh
     npm install
     ```
+
 5. Use `Run Extension` from VS Code's `Run and Debug` view.
 
 ## Contributors
@@ -27,5 +31,6 @@ Thanks so much to everyone [who has contributed](https://github.com/SanjulaGanep
 * [@ChristopherHX](https://github.com/ChristopherHX)
 * [@a11rew](https://github.com/a11rew)
 * [@atoko](https://github.com/atoko)
+* [@ghbuck](https://github.com/ghbuck)
 
 Want to see your name on this list? Join us and contribute!

--- a/src/settingsManager.ts
+++ b/src/settingsManager.ts
@@ -55,6 +55,10 @@ export enum SettingFileName {
     payloadFile = 'payload.json'
 }
 
+enum SettingYamlKey {
+    runners = 'runs-on'
+}
+
 export class SettingsManager {
     storageManager: StorageManager;
     secretManager: SecretManager;
@@ -62,7 +66,6 @@ export class SettingsManager {
     static secretsRegExp: RegExp = /\${{\s*secrets\.(.*?)\s*}}/g;
     static variablesRegExp: RegExp = /\${{\s*vars\.(.*?)(?:\s*==\s*(.*?))?\s*}}/g;
     static inputsRegExp: RegExp = /\${{\s*(?:inputs|github\.event\.inputs)\.(.*?)(?:\s*==\s*(.*?))?\s*}}/g;
-    static runnersRegExp: RegExp = /runs-on:\s*(.+)/g;
 
     constructor(storageManager: StorageManager, secretManager: SecretManager) {
         this.storageManager = storageManager;
@@ -87,7 +90,7 @@ export class SettingsManager {
         const variableFiles = (await this.getCustomSettings(workspaceFolder, StorageKey.VariableFiles)).filter(variableFile => !isUserSelected || variableFile.selected);
         const inputs = (await this.getSetting(workspaceFolder, SettingsManager.inputsRegExp, StorageKey.Inputs, false, Visibility.show)).filter(input => !isUserSelected || (input.selected && input.value));
         const inputFiles = (await this.getCustomSettings(workspaceFolder, StorageKey.InputFiles)).filter(inputFile => !isUserSelected || inputFile.selected);
-        const runners = (await this.getSetting(workspaceFolder, SettingsManager.runnersRegExp, StorageKey.Runners, false, Visibility.show)).filter(runner => !isUserSelected || (runner.selected && runner.value));
+        const runners = (await this.getSetting(workspaceFolder, SettingYamlKey.runners, StorageKey.Runners, false, Visibility.show)).filter(runner => !isUserSelected || (runner.selected && runner.value));
         const payloadFiles = (await this.getCustomSettings(workspaceFolder, StorageKey.PayloadFiles)).filter(payloadFile => !isUserSelected || payloadFile.selected);
         const options = (await this.getCustomSettings(workspaceFolder, StorageKey.Options)).filter(option => !isUserSelected || (option.selected && (option.path || option.notEditable)));
         // const environments = await this.getEnvironments(workspaceFolder);
@@ -106,7 +109,7 @@ export class SettingsManager {
         };
     }
 
-    async getSetting(workspaceFolder: WorkspaceFolder, regExp: RegExp, storageKey: StorageKey, password: boolean, visible: Visibility, defaultSettings: Setting[] = []): Promise<Setting[]> {
+    async getSetting(workspaceFolder: WorkspaceFolder, finder: RegExp | SettingYamlKey, storageKey: StorageKey, password: boolean, visible: Visibility, defaultSettings: Setting[] = []): Promise<Setting[]> {
         const settings: Setting[] = defaultSettings;
 
         const workflows = await act.workflowsManager.getWorkflows(workspaceFolder);
@@ -115,7 +118,13 @@ export class SettingsManager {
                 continue;
             }
 
-            const workflowSettings = this.findInWorkflow(workflow.fileContent, regExp, password, visible);
+            let workflowSettings: Setting[];
+            if (finder instanceof RegExp) {
+                workflowSettings = this.findInWorkflow(workflow.fileContent, finder, password, visible);
+            } else {
+                workflowSettings = this.findInYaml(workflow.yaml, finder, password, visible);
+            }
+
             for (const workflowSetting of workflowSettings) {
                 const existingSetting = settings.find(setting => setting.key === workflowSetting.key);
                 if (!existingSetting) {
@@ -317,6 +326,43 @@ export class SettingsManager {
         const matches = content.matchAll(regExp);
         for (const match of matches) {
             results.push({ key: match[1], value: '', password: password, selected: false, visible: visible, mode: Mode.manual });
+        }
+
+        return results;
+    }
+
+    private findInYaml(yamlContent: object, targetKey: SettingYamlKey, password: boolean, visible: Visibility) {
+        const results: Setting[] = [];
+
+        if (!yamlContent) {
+            return results;
+        }
+        
+        const stack = [yamlContent];
+
+        while (stack.length > 0) {
+            const current = stack.pop();
+
+            if (current && typeof current === 'object') {
+                if (Array.isArray(current)) {
+                    stack.push(...current);
+                } else {
+                    for (const [currentKey, currentValue] of Object.entries(current)) {
+                        if (currentKey === targetKey) {
+                            if (Array.isArray(currentValue)) {
+                                for (const item of currentValue) {
+                                    results.push({ key: item, value: '', password: password, selected: false, visible: visible, mode: Mode.manual });
+                                }
+                            } else {
+                                results.push({ key: currentValue, value: '', password: password, selected: false, visible: visible, mode: Mode.manual });
+                            }
+                        }
+                        if (currentValue && typeof currentValue === 'object') {
+                            stack.push(currentValue);
+                        }
+                    }
+                }
+            }
         }
 
         return results;

--- a/src/settingsManager.ts
+++ b/src/settingsManager.ts
@@ -337,7 +337,7 @@ export class SettingsManager {
         if (!yamlContent) {
             return results;
         }
-        
+
         const stack = [yamlContent];
 
         while (stack.length > 0) {
@@ -352,6 +352,12 @@ export class SettingsManager {
                             if (Array.isArray(currentValue)) {
                                 for (const item of currentValue) {
                                     results.push({ key: item, value: '', password: password, selected: false, visible: visible, mode: Mode.manual });
+                                }
+                            } else if (typeof currentValue === 'object') {
+                                // this is a specific case for 'runs-on' when it's using a 'group' object
+                                // if findInYaml is extended to other keys, a better way to handle different object structures will be needed
+                                if (targetKey === SettingYamlKey.runners && currentValue['group']) {
+                                    results.push({ key: currentValue['group'], value: '', password: password, selected: false, visible: visible, mode: Mode.manual });
                                 }
                             } else {
                                 results.push({ key: currentValue, value: '', password: password, selected: false, visible: visible, mode: Mode.manual });


### PR DESCRIPTION
### ✍ Changes

This pull request refactors how runner settings are extracted from workflow files in the `SettingsManager` class. Instead of relying on regular expressions to parse the `runs-on` key from workflow YAML, it introduces a more robust method that traverses the YAML object structure directly. This improves reliability and maintainability when reading runner settings.

**Runner extraction improvements:**

* Added a new `SettingYamlKey` enum to define YAML keys, specifically `runs-on`, for more explicit and type-safe access to workflow settings.
* Replaced the use of a regular expression for finding runners with a reference to the new `SettingYamlKey.runners` value in the `getSetting` method, making the extraction logic clearer and less error-prone.
* Updated the signature of the `getSetting` method to accept either a regular expression or a `SettingYamlKey`, enabling more flexible and context-aware extraction of settings.
* Refactored the workflow settings extraction logic to use a new method, `findInYaml`, when a `SettingYamlKey` is provided, ensuring that YAML keys are searched using object traversal rather than string matching.

**New YAML traversal utility:**

* Implemented the `findInYaml` method, which parses the workflow YAML object by iterative traversal with a stack to locate the specified key and extract runner settings, handling both arrays and single values.

> [!NOTE]
> There is a comment in `findInYaml` about a singular use-case for `runs-on` specifically. I'm not sure another workflow config key allows for a basic string, a string array, or an object, so perhaps quite the edge case. Either way, it's worth the call out and recognition that if other settings can be this varied, then this section would very much need to be refactored and abstracted.

**Documentation:**

* Added `@ghbuck` to the list of contributors in `CONTRIBUTING.md`.

### 📋 Checklist
<!-- Complete the checklist -->
- [x] I tested my changes
- [x] I updated relevant documentation
- [x] I added myself to the [contributors' list](https://github.com/SanjulaGanepola/github-local-actions/blob/main/CONTRIBUTING.md#contributors)